### PR TITLE
Graceful shutdown

### DIFF
--- a/configs/config-depl.json
+++ b/configs/config-depl.json
@@ -2,7 +2,6 @@
     "version": "1.0",
     "zookeepers": [ "zookeeper" ],
     "clusterId": "iudx-rs-cluster",
-    "host": "server",
     "modules": [
         {
             "id": "iudx.resource.server.database.DatabaseVerticle",

--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -2,7 +2,6 @@
     "version": "1.0",
     "zookeepers": [ "zookeeper" ],
     "clusterId": "iudx-rs-cluster",
-    "host": "server",
     "modules": [
         {
             "id": "iudx.resource.server.database.DatabaseVerticle",

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -10,14 +10,12 @@ services:
   prod:
     image: iudx/rs-depl:latest
     environment:
-      - HOSTNAME=server
-      - ZOOKEEPER=zookeeper
       - RS_URL=https://rs.iudx.org.in
+      - LOG_LEVEL=INFO
     volumes:
       - ./configs/config-depl.json:/usr/share/app/configs/config.json
       - ./docs/:/usr/share/app/docs
       - ./configs/keystore.jks:/usr/share/app/configs/keystore.jks
-      - /tmp/iudx/:/tmp/iudx/
     depends_on:
       - "zookeeper"
     ports:
@@ -31,17 +29,17 @@ services:
          options:
              max-file: "5"
              max-size: "100m"
-    command: "java -jar ./fatjar.jar -c configs/config.json"
+    command: bash -c "exec java -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"
 
   dev:
     image: iudx/rs-dev:latest
     environment:
       - RS_URL=https://rs.iudx.org.in
+      - LOG_LEVEL=INFO
     volumes:
       - ./configs/config-dev.json:/usr/share/app/configs/config.json
       - ./configs/keystore.jks:/usr/share/app/configs/keystore.jks
       - ./docs/:/usr/share/app/docs
-      - /tmp/iudx/:/tmp/iudx/
     ports:
       - "8080:80"
       - "9000:9000"
@@ -53,7 +51,7 @@ services:
          options:
              max-file: "5"
              max-size: "100m"
-    command: "java -jar ./fatjar.jar -c configs/config.json"
+    command: bash -c "exec java -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"
 
   zookeeper:
     image: zookeeper:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
   prod:
     image: iudx/rs-depl:latest
     environment:
-      - HOSTNAME=server
-      - ZOOKEEPER=zookeeper
       - RS_URL=https://rs.iudx.org.in
       - LOG_LEVEL=INFO
     volumes:
@@ -28,7 +26,7 @@ services:
          options:
              max-file: "5"
              max-size: "100m"
-    command: "java -jar ./fatjar.jar -c configs/config.json"
+    command: bash -c "exec java  -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"
 
   dev:
     image: iudx/rs-dev:latest
@@ -50,7 +48,7 @@ services:
          options:
              max-file: "5"
              max-size: "100m"
-    command: "java -jar ./fatjar.jar -c configs/config.json"
+    command: bash -c "exec java -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"
 
   zookeeper:
     image: zookeeper:latest

--- a/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
@@ -1501,4 +1501,12 @@ public class ApiServerVerticle extends AbstractVerticle {
     return Optional.of(queryParams);
   }
 
+
+
+  @Override
+  public void stop() {
+	System.out.println("Stopping an API server");
+  }
 }
+
+

--- a/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
@@ -1505,7 +1505,7 @@ public class ApiServerVerticle extends AbstractVerticle {
 
   @Override
   public void stop() {
-	System.out.println("Stopping an API server");
+	LOGGER.info("Stopping the API server");
   }
 }
 

--- a/src/main/java/iudx/resource/server/authenticator/AuthenticationVerticle.java
+++ b/src/main/java/iudx/resource/server/authenticator/AuthenticationVerticle.java
@@ -57,20 +57,19 @@ public class AuthenticationVerticle extends AbstractVerticle {
 
   @Override
   public void start() throws Exception {
-	binder = new ServiceBinder(vertx);
+    binder = new ServiceBinder(vertx);
     authentication = new AuthenticationServiceImpl(vertx, createWebClient(vertx, config()), config());
 
     /* Publish the Authentication service with the Event Bus against an address. */
 
-    consumer=binder.setAddress(AUTH_SERVICE_ADDRESS)
+    consumer = binder.setAddress(AUTH_SERVICE_ADDRESS)
       .register(AuthenticationService.class, authentication);
   }
 
   @Override
   public void stop() {
 	binder.unregister(consumer);
-	System.out.println("verticle stopped");
   }
- }
+}
 
 

--- a/src/main/java/iudx/resource/server/authenticator/AuthenticationVerticle.java
+++ b/src/main/java/iudx/resource/server/authenticator/AuthenticationVerticle.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.JksOptions;
 import io.vertx.ext.web.client.WebClient;
@@ -29,7 +30,8 @@ public class AuthenticationVerticle extends AbstractVerticle {
   private static final String AUTH_SERVICE_ADDRESS = "iudx.rs.authentication.service";
   private static final Logger LOGGER = LogManager.getLogger(AuthenticationVerticle.class);
   private AuthenticationService authentication;
-
+  private ServiceBinder binder;
+  private MessageConsumer<JsonObject> consumer;
   static WebClient createWebClient(Vertx vertx, JsonObject config) {
     return createWebClient(vertx, config, false);
   }
@@ -55,12 +57,20 @@ public class AuthenticationVerticle extends AbstractVerticle {
 
   @Override
   public void start() throws Exception {
-
+	binder = new ServiceBinder(vertx);
     authentication = new AuthenticationServiceImpl(vertx, createWebClient(vertx, config()), config());
 
     /* Publish the Authentication service with the Event Bus against an address. */
 
-    new ServiceBinder(vertx).setAddress(AUTH_SERVICE_ADDRESS)
+    consumer=binder.setAddress(AUTH_SERVICE_ADDRESS)
       .register(AuthenticationService.class, authentication);
   }
-}
+
+  @Override
+  public void stop() {
+	binder.unregister(consumer);
+	System.out.println("verticle stopped");
+  }
+ }
+
+

--- a/src/main/java/iudx/resource/server/callback/CallbackVerticle.java
+++ b/src/main/java/iudx/resource/server/callback/CallbackVerticle.java
@@ -116,12 +116,13 @@ public class CallbackVerticle extends AbstractVerticle {
     propObj.put("callbackpoolSize", poolSize);
 
     /* Call the callback constructor with the RabbitMQ client. */
-	binder = new ServiceBinder(vertx);    
+    binder = new ServiceBinder(vertx);
     callback = new CallbackServiceImpl(client, webClient, propObj, vertx);
 
     /* Publish the Callback service with the Event Bus against an address. */
 
-    consumer = binder.setAddress(CALLBACK_SERVICE_ADDRESS)
+    consumer =
+        binder.setAddress(CALLBACK_SERVICE_ADDRESS)
       .register(CallbackService.class, callback);
 
     LOGGER.info("Callback Verticle started");
@@ -130,7 +131,6 @@ public class CallbackVerticle extends AbstractVerticle {
   @Override
   public void stop() {
 	binder.unregister(consumer);
-	System.out.println("verticle stopped");
   }
 }
 

--- a/src/main/java/iudx/resource/server/database/DatabaseVerticle.java
+++ b/src/main/java/iudx/resource/server/database/DatabaseVerticle.java
@@ -1,6 +1,8 @@
 package iudx.resource.server.database;
 
 import io.vertx.core.AbstractVerticle;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.json.JsonObject;
 import io.vertx.serviceproxy.ServiceBinder;
 import java.io.InputStream;
 import java.util.Properties;
@@ -29,6 +31,8 @@ public class DatabaseVerticle extends AbstractVerticle {
   private String timeLimit;
   private int databasePort;
   private static final String DATABASE_SERVICE_ADDRESS = "iudx.rs.database.service";
+  private ServiceBinder binder;
+  private MessageConsumer<JsonObject> consumer;
 
   /**
    * This method is used to start the Verticle. It deploys a verticle in a cluster, registers the
@@ -47,10 +51,19 @@ public class DatabaseVerticle extends AbstractVerticle {
     password = config().getString("dbPassword");
     timeLimit = config().getString("timeLimit");
 
-    client = new ElasticClient(databaseIP, databasePort, user, password);    
+    client = new ElasticClient(databaseIP, databasePort, user, password); 
+	binder = new ServiceBinder(vertx);
     database = new DatabaseServiceImpl(client, timeLimit);
 
-    new ServiceBinder(vertx).setAddress(DATABASE_SERVICE_ADDRESS)
+    consumer=binder.setAddress(DATABASE_SERVICE_ADDRESS)
         .register(DatabaseService.class, database);
   }
-}
+
+
+  @Override
+  public void stop() {
+	binder.unregister(consumer);
+	System.out.println("verticle stopped");
+  }
+ }
+

--- a/src/main/java/iudx/resource/server/database/DatabaseVerticle.java
+++ b/src/main/java/iudx/resource/server/database/DatabaseVerticle.java
@@ -52,10 +52,11 @@ public class DatabaseVerticle extends AbstractVerticle {
     timeLimit = config().getString("timeLimit");
 
     client = new ElasticClient(databaseIP, databasePort, user, password); 
-	binder = new ServiceBinder(vertx);
+    binder = new ServiceBinder(vertx);
     database = new DatabaseServiceImpl(client, timeLimit);
 
-    consumer=binder.setAddress(DATABASE_SERVICE_ADDRESS)
+    consumer =
+        binder.setAddress(DATABASE_SERVICE_ADDRESS)
         .register(DatabaseService.class, database);
   }
 
@@ -63,7 +64,6 @@ public class DatabaseVerticle extends AbstractVerticle {
   @Override
   public void stop() {
 	binder.unregister(consumer);
-	System.out.println("verticle stopped");
   }
- }
+}
 

--- a/src/main/java/iudx/resource/server/databroker/DataBrokerVerticle.java
+++ b/src/main/java/iudx/resource/server/databroker/DataBrokerVerticle.java
@@ -157,13 +157,14 @@ public class DataBrokerVerticle extends AbstractVerticle {
     pgClient = new PostgresClient(vertx, connectOptions, poolOptions);
     rabbitClient =
         new RabbitClient(vertx, config, rabbitWebClient, pgClient);
-	binder = new ServiceBinder(vertx);
+    binder = new ServiceBinder(vertx);
     databroker = new DataBrokerServiceImpl(rabbitClient, pgClient, dataBrokerVhost);
 
 
     /* Publish the Data Broker service with the Event Bus against an address. */
 
-    consumer=binder.setAddress(BROKER_SERVICE_ADDRESS)
+    consumer =
+        binder.setAddress(BROKER_SERVICE_ADDRESS)
       .register(DataBrokerService.class, databroker);
 
   }
@@ -171,8 +172,7 @@ public class DataBrokerVerticle extends AbstractVerticle {
 
   @Override
   public void stop() {
-	binder.unregister(consumer);
-	System.out.println("verticle stopped");
+    binder.unregister(consumer);
   }
 }
 

--- a/src/main/java/iudx/resource/server/deploy/Deployer.java
+++ b/src/main/java/iudx/resource/server/deploy/Deployer.java
@@ -41,6 +41,7 @@ import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
 
 public class Deployer {
   private static final Logger LOGGER = LogManager.getLogger(Deployer.class);
@@ -142,74 +143,68 @@ public class Deployer {
 
   }
 
-	public static void gracefulShutdown() {
-		Set <String> deployIDSet=vertx.deploymentIDs();
-		System.out.println("number of verticles being undeployed are:"+ deployIDSet.size());
-		CountDownLatch latch_verticles = new CountDownLatch(deployIDSet.size()); 
-		CountDownLatch latch_cluster = new CountDownLatch(1); 
-		CountDownLatch latch_vertx = new CountDownLatch(1);
-		for (String deploymentID : deployIDSet) {
-			vertx.undeploy(deploymentID, handler -> {
-			if (handler.succeeded()) {
-				LOGGER.info(deploymentID+" verticle  successfully Undeployed");
-				latch_verticles.countDown();
-			} else {
-				LOGGER.error(deploymentID+ "Undeploy failed!");
-			}
+  public static void gracefulShutdown() {
+    Set<String> deployIDSet = vertx.deploymentIDs();
+    Logger LOGGER = LogManager.getLogger(Deployer.class);
+    LOGGER.info("Shutting down the application");
+    CountDownLatch latch_verticles = new CountDownLatch(deployIDSet.size());
+    CountDownLatch latch_cluster = new CountDownLatch(1);
+    CountDownLatch latch_vertx = new CountDownLatch(1);
+    LOGGER.debug("number of verticles being undeployed are:" + deployIDSet.size());
+    for (String deploymentID : deployIDSet) {
+      vertx.undeploy(deploymentID, handler -> {
+        if (handler.succeeded()) {
+          LOGGER.debug(deploymentID + " verticle  successfully Undeployed");
+          latch_verticles.countDown();
+        } else {
+          LOGGER.warn(deploymentID + "Undeploy failed!");
+        }
 
-		});
-			
-		
-		}
-		try { 
-			latch_verticles.await(5, TimeUnit.SECONDS);
-			mgr.leave(handler->{
-				if(handler.succeeded()){							
-					System.out.println("Hazelcast succesfully left:"+handler.result());
-					latch_cluster.countDown();
-									
-				}
-				else
-				{
-					
-				System.out.println("Error while hazelcast leaving:"+handler.cause());
-				}
-			});
-		}
-		catch(Exception e) {
-				e.printStackTrace();
-		}
+      });
+    }
 
-		try {
-			latch_cluster.await(5, TimeUnit.SECONDS);
-			System.out.println("Closing vertx");		
-			vertx.close(handler->{
-				if(handler.succeeded()){
-					System.out.println("vertx closed succesfully:"+handler.result());
-					latch_vertx.countDown();		
-				}
-				else
-				{
-					System.out.println("Error vertx didn't close properly, reason:"+ handler.cause());
-					
-				}
-			});
-			
+    try {
+      latch_verticles.await(5, TimeUnit.SECONDS);
+      LOGGER.info("All the verticles undeployed");
+      mgr.leave(handler -> {
+        if (handler.succeeded()) {
+          LOGGER.info("Hazelcast succesfully left:");
+          latch_cluster.countDown();
 
-		} 
-		catch(Exception e) {
-			e.printStackTrace();
-		}
+        } else {
+          LOGGER.warn("Error while hazelcast leaving, reason:" + handler.cause());
+        }
+      });
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
 
-		try {
-			latch_vertx.await(5, TimeUnit.SECONDS);
-		}
-		
-		catch(Exception e) {
-			e.printStackTrace();
-		}
-		
-	}
+    try {
+      latch_cluster.await(5, TimeUnit.SECONDS);
+      vertx.close(handler -> {
+        if (handler.succeeded()) {
+          LOGGER.info("vertx closed succesfully");
+          latch_vertx.countDown();
+        } else {
+          LOGGER.warn("Vertx didn't close properly, reason:" + handler.cause());
+        }
+      });
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    try {
+      latch_vertx.await(5, TimeUnit.SECONDS);
+      // then shut down log4j
+      if( LogManager.getContext() instanceof LoggerContext ) {
+        LOGGER.debug("Shutting down log4j2");
+        LogManager.shutdown((LoggerContext) LogManager.getContext());
+      } else
+        LOGGER.warn("Unable to shutdown log4j2");
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
 
   public static void main(String[] args) {
     CLI cli = CLI.create("IUDX Rs").setSummary("A CLI to deploy the resource")
@@ -218,22 +213,22 @@ public class Deployer {
         .addOption(new Option().setLongName("config").setShortName("c")
             .setRequired(true).setDescription("configuration file"))
         .addOption(new Option().setLongName("host").setShortName("i").setRequired(true)
-				.setDescription("public host"));;
+            .setDescription("public host"));;
 
     StringBuilder usageString = new StringBuilder();
     cli.usage(usageString);
     CommandLine commandLine = cli.parse(Arrays.asList(args), false);
     if (commandLine.isValid() && !commandLine.isFlagEnabled("help")) {
       String configPath = commandLine.getOptionValue("config");
-	  String host = commandLine.getOptionValue("host");
+      String host = commandLine.getOptionValue("host");
       deploy(configPath,host);
-	  Runtime.getRuntime().addShutdownHook(new Thread(() -> gracefulShutdown()));		
-
+      Runtime.getRuntime().addShutdownHook(new Thread(() -> gracefulShutdown()));
     } else {
       LOGGER.info(usageString);
     }
   }
 
 }
+
 
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN">
+<Configuration status="WARN" shutdownHook="disable">
     <Properties>
         <Property name="LOG_EXCEPTION_CONVERSION_WORD">%xEx</Property>
         <Property name="LOG_LEVEL_PATTERN">%p</Property>


### PR DESCRIPTION
It implements graceful shutdown of vertx cluster. 
Removes taking hostname from configs instead it takes from the cmdline in docker-compose files. 
-  to feed the randomly generated container ids as hostnames to hazelcast cluster instead of setting the hostname which would be a limitation in scaling of containers.