### PR TITLE
Correcting metrics and gracefulShudtdown in vertx4

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -12,6 +12,7 @@ services:
     environment:
       - RS_URL=https://rs.iudx.org.in
       - LOG_LEVEL=INFO
+      - RS_JAVA_OPTS=-Xmx4096m
     volumes:
       - ./configs/config-depl.json:/usr/share/app/configs/config.json
       - ./docs/:/usr/share/app/docs
@@ -29,13 +30,14 @@ services:
          options:
              max-file: "5"
              max-size: "100m"
-    command: bash -c "exec java -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"
+    command: bash -c "exec java $$RS_JAVA_OPTS  -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"
 
   dev:
     image: iudx/rs-dev:latest
     environment:
       - RS_URL=https://rs.iudx.org.in
       - LOG_LEVEL=INFO
+      - RS_JAVA_OPTS=-Xmx1024m
     volumes:
       - ./configs/config-dev.json:/usr/share/app/configs/config.json
       - ./configs/keystore.jks:/usr/share/app/configs/keystore.jks
@@ -51,7 +53,8 @@ services:
          options:
              max-file: "5"
              max-size: "100m"
-    command: bash -c "exec java -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"
+    command: bash -c "exec java $$RS_JAVA_OPTS  -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"
+
 
   zookeeper:
     image: zookeeper:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
       - RS_URL=https://rs.iudx.org.in
       - LOG_LEVEL=INFO
+      - RS_JAVA_OPTS=-Xmx4096m
     volumes:
       - ./configs/config-depl.json:/usr/share/app/configs/config.json
       - ./docs/:/usr/share/app/docs
@@ -26,13 +27,15 @@ services:
          options:
              max-file: "5"
              max-size: "100m"
-    command: bash -c "exec java  -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"
+    command: bash -c "exec java $$RS_JAVA_OPTS  -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"
+
 
   dev:
     image: iudx/rs-dev:latest
     environment:
       - RS_URL=https://rs.iudx.org.in
       - LOG_LEVEL=DEBUG
+      - RS_JAVA_OPTS=-Xmx1024m
     volumes:
       - ./configs/config-dev.json:/usr/share/app/configs/config.json
       - ./configs/keystore.jks:/usr/share/app/configs/keystore.jks
@@ -48,7 +51,7 @@ services:
          options:
              max-file: "5"
              max-size: "100m"
-    command: bash -c "exec java -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"
+    command: bash -c "exec java $$RS_JAVA_OPTS  -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"
 
   zookeeper:
     image: zookeeper:latest

--- a/docker/depl.dockerfile
+++ b/docker/depl.dockerfile
@@ -1,6 +1,6 @@
 ARG VERSION="0.0.1-SNAPSHOT"
 
-FROM maven:latest as dependencies
+FROM maven:3-openjdk-11-slim as dependencies
 
 WORKDIR /usr/share/app
 COPY pom.xml .
@@ -14,7 +14,7 @@ COPY src src
 RUN mvn clean package -Dmaven.test.skip=true
 
 
-FROM openjdk:14-slim-buster
+FROM openjdk:11-jre-slim-buster
 
 ARG VERSION
 ENV JAR="iudx.resource.server-cluster-${VERSION}-fat.jar"

--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -1,8 +1,7 @@
 # Run from project root directory
-
 ARG VERSION="0.0.1-SNAPSHOT"
 
-FROM maven:latest as dependencies
+FROM maven:3-openjdk-11-slim as dependencies
 
 WORKDIR /usr/share/app
 COPY pom.xml .
@@ -16,7 +15,7 @@ COPY src src
 RUN mvn clean package -Dmaven.test.skip=true
 
 
-FROM openjdk:14-slim-buster
+FROM openjdk:11-jre-slim-buster
 
 ARG VERSION
 ENV JAR="iudx.resource.server-dev-${VERSION}-fat.jar"

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<vertx.version>4.0.3</vertx.version>
 		<openjdk.version>11</openjdk.version>
 		<hazelcast.version>4.0.2</hazelcast.version>
-		<micrometer.version>1.7.0</micrometer.version>
+		<micrometer.version>1.6.2</micrometer.version>
 		<curator.version>5.1.0</curator.version>
 		<apache-commons-lang3.version>3.12.0</apache-commons-lang3.version>
 		<junit-jupiter-engine.version>5.7.1</junit-jupiter-engine.version>
@@ -18,6 +18,7 @@
 		<lmax-disruptor.version>3.4.4</lmax-disruptor.version>
 		<jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
 		<checkstyle.version>8.42</checkstyle.version>
+		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
 		<maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
 		<exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
@@ -28,8 +29,6 @@
 		<junit-jupiter.params>5.5.2</junit-jupiter.params>
 		<slf4j.version>1.7.25</slf4j.version>
 		<jts2geojson.version>0.16.1</jts2geojson.version>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<exec.mainClass>iudx.resource.server.deploy.Deployer</exec.mainClass>
 		<exec.mainClassDev>iudx.resource.server.deploy.DeployerDev
@@ -316,6 +315,8 @@
 									implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
 									<resource>META-INF/services/io.vertx.core.spi.VerticleFactory
 									</resource>
+									<resource>META-INF/services/io.vertx.core.spi.VertxServiceProvider
+									</resource>
 								</transformer>
 							</transformers>
 							<artifactSet></artifactSet>
@@ -352,6 +353,8 @@
 									implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
 									<resource>META-INF/services/io.vertx.core.spi.VerticleFactory
 									</resource>
+									<resource>META-INF/services/io.vertx.core.spi.VertxServiceProvider
+									</resource>
 								</transformer>
 							</transformers>
 							<artifactSet></artifactSet>
@@ -366,8 +369,8 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>${maven-javadoc-plugin.version}</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>${openjdk.version}</source>
+					<target>${openjdk.version}</target>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -398,9 +401,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${maven-compiler-plugin.version}</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>${openjdk.version}</source>
+					<target>${openjdk.version}</target>
 					<annotationProcessors>
 						<annotationProcessor>io.vertx.codegen.CodeGenProcessor</annotationProcessor>
 					</annotationProcessors>
@@ -416,7 +420,7 @@
 				<artifactId>maven-pmd-plugin</artifactId>
 				<version>${maven-pmd-plugin.version}</version>
 				<configuration>
-					<targetJdk>13</targetJdk>
+					<targetJdk>${openjdk.version}</targetJdk>
 					<rulesets>
 						<ruleset>/rulesets/java/braces.xml</ruleset>
 						<ruleset>/rulesets/java/naming.xml</ruleset>


### PR DESCRIPTION
- Correction of metrics in vertx4, by including 'META-INF/services/io.vertx.core.spi.VertxServiceProvider' in transformer in pom.xml,  [refer issue](https://github.com/eclipse-vertx/vert.x/issues/3772).

- Proper configuration of logging, so that vertx components also logs using log4j2, [refer docs](https://vertx.io/docs/vertx-core/java/#_logging).
- changing dockerfiles to openjdk 11
- changing cluster manager leave method with promise as param instead of
  handler