### PR TITLE
Redis docker tuning

### DIFF
--- a/configs/config-depl.json
+++ b/configs/config-depl.json
@@ -90,10 +90,7 @@
             "redisMode": "CLUSTER",
             "redisUsername": "",
             "redisPassword": "",
-            "redisMaxPoolSize": 30,
-            "redisMaxPoolWaiting": 200,
             "redisMaxWaitingHandlers": 1024,
-            "redisPoolRecycleTimeout": 1500,
             "redisHost":"",
             "redisPort": 1234
 

--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -85,15 +85,16 @@
             "catServerPort": 443
         },
         {
-            "id": "iudx.resource.server.database.latest.LatestVerticle",
+           "id": "iudx.resource.server.database.latest.LatestVerticle",
             "verticleInstances": 2,
-            "redisHost": "",
-            "redisPort": 28734,
-            "redisUser": "",
+            "attributeList": {"itms-info": "some-attr"},
+            "redisMode": "STANDALONE",
+            "redisUsername": "",
             "redisPassword": "",
-            "attributeList": {
-                "key": "value"
-            }
+            "redisMaxWaitingHandlers": 1024,
+            "redisHost":"",
+            "redisPort": 1234
+
         },
         {
          	"id": "iudx.resource.server.metering.MeteringVerticle",

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -15,7 +15,6 @@ services:
       - RS_JAVA_OPTS=-Xmx4096m
     volumes:
       - ./configs/config-depl.json:/usr/share/app/configs/config.json
-      - ./docs/:/usr/share/app/docs
       - ./configs/keystore.jks:/usr/share/app/configs/keystore.jks
     depends_on:
       - "zookeeper"
@@ -41,7 +40,6 @@ services:
     volumes:
       - ./configs/config-dev.json:/usr/share/app/configs/config.json
       - ./configs/keystore.jks:/usr/share/app/configs/keystore.jks
-      - ./docs/:/usr/share/app/docs
     ports:
       - "8080:80"
       - "9000:9000"

--- a/docker-compose.temp.yml
+++ b/docker-compose.temp.yml
@@ -1,0 +1,15 @@
+version: '3.7'
+networks:
+  overlay-net:
+    external: true      
+    driver: overlay
+services:
+  rs:
+    image: dockerhub.iudx.io/iudx/rs-depl:2.5.Zookeeper
+    volumes:
+      - ./secrets/all-verticles-configs/config-depl.json:/usr/share/app/secrets/all-verticles-configs/config.json
+    ports:
+      - "80:80"
+      - "9000:9000"
+    networks: 
+      - overlay-net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       - RS_JAVA_OPTS=-Xmx4096m
     volumes:
       - ./configs/config-depl.json:/usr/share/app/configs/config.json
-      - ./docs/:/usr/share/app/docs
       - ./configs/keystore.jks:/usr/share/app/configs/keystore.jks
     ports:
       - "443:8443"
@@ -39,7 +38,6 @@ services:
     volumes:
       - ./configs/config-dev.json:/usr/share/app/configs/config.json
       - ./configs/keystore.jks:/usr/share/app/configs/keystore.jks
-      - ./docs/:/usr/share/app/docs
     ports:
       - "8443:8443"
       - "9000:9000"

--- a/docker/build-push.sh
+++ b/docker/build-push.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+MAJOR_RELEASE=3
+MINOR_RELEASE=0
+PR_NO=`git ls-remote upstream  'pull/*/head' | grep -F -f <(git log --no-merges -1 --pretty=%h) | awk -F'/' '{print $3}'` # last closed PR, when built from master branch
+
+# To be executed from project root
+docker build -t dockerhub.iudx.io/iudx/rs-depl:$MAJOR_RELEASE.$MINOR_RELEASE-$PR_NO -f docker/depl.dockerfile . && \
+docker push dockerhub.iudx.io/iudx/rs-depl:$MAJOR_RELEASE.$MINOR_RELEASE-$PR_NO
+
+docker build -t dockerhub.iudx.io/iudx/rs-dev:$MAJOR_RELEASE.$MINOR_RELEASE-$PR_NO -f docker/dev.dockerfile . && \
+docker push dockerhub.iudx.io/iudx/rs-dev:$MAJOR_RELEASE.$MINOR_RELEASE-$PR_NO

--- a/docker/depl.dockerfile
+++ b/docker/depl.dockerfile
@@ -21,3 +21,4 @@ ENV JAR="iudx.resource.server-cluster-${VERSION}-fat.jar"
 
 WORKDIR /usr/share/app
 COPY --from=builder /usr/share/app/target/${JAR} ./fatjar.jar
+COPY docs docs

--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -22,3 +22,4 @@ ENV JAR="iudx.resource.server-dev-${VERSION}-fat.jar"
 
 WORKDIR /usr/share/app
 COPY --from=builder /usr/share/app/target/${JAR} ./fatjar.jar
+COPY docs docs


### PR DESCRIPTION
- use of one connection per redis verticle instance with pipelining using maxwaiting handlers
similar to PR datakaveri/latest-ingestion-pipeline#8
- adding docs files to image instead of mounting
- adding temporary docker build push script
