### PR TITLE
Adding small patch to docker push and dockerfiles

### DIFF
--- a/docker/build-push.sh
+++ b/docker/build-push.sh
@@ -2,11 +2,11 @@
 
 MAJOR_RELEASE=3
 MINOR_RELEASE=0
-PR_NO=`git ls-remote upstream  'pull/*/head' | grep -F -f <(git log --no-merges -1 --pretty=%h) | awk -F'/' '{print $3}'` # last closed PR, when built from master branch
-
+COMMIT_ID=`git log  -1 --pretty=%h`
+# last commit id of master branch
 # To be executed from project root
-docker build -t dockerhub.iudx.io/iudx/rs-depl:$MAJOR_RELEASE.$MINOR_RELEASE-$PR_NO -f docker/depl.dockerfile . && \
-docker push dockerhub.iudx.io/iudx/rs-depl:$MAJOR_RELEASE.$MINOR_RELEASE-$PR_NO
+docker build -t dockerhub.iudx.io/iudx/rs-depl:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID -f docker/depl.dockerfile . && \
+docker push dockerhub.iudx.io/iudx/rs-depl:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID
 
-docker build -t dockerhub.iudx.io/iudx/rs-dev:$MAJOR_RELEASE.$MINOR_RELEASE-$PR_NO -f docker/dev.dockerfile . && \
-docker push dockerhub.iudx.io/iudx/rs-dev:$MAJOR_RELEASE.$MINOR_RELEASE-$PR_NO
+docker build -t dockerhub.iudx.io/iudx/rs-dev:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID -f docker/dev.dockerfile . && \
+docker push dockerhub.iudx.io/iudx/rs-dev:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID

--- a/docker/depl.dockerfile
+++ b/docker/depl.dockerfile
@@ -20,5 +20,5 @@ ARG VERSION
 ENV JAR="iudx.resource.server-cluster-${VERSION}-fat.jar"
 
 WORKDIR /usr/share/app
-COPY --from=builder /usr/share/app/target/${JAR} ./fatjar.jar
 COPY docs docs
+COPY --from=builder /usr/share/app/target/${JAR} ./fatjar.jar

--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -21,5 +21,5 @@ ARG VERSION
 ENV JAR="iudx.resource.server-dev-${VERSION}-fat.jar"
 
 WORKDIR /usr/share/app
-COPY --from=builder /usr/share/app/target/${JAR} ./fatjar.jar
 COPY docs docs
+COPY --from=builder /usr/share/app/target/${JAR} ./fatjar.jar


### PR DESCRIPTION
- use of commit-id instead of PR no in tagging, as commit id is unique and less
confusing to get from the 'git log'