### PR TITLE
Remove HTTP_PATH label

### DIFF
--- a/src/main/java/iudx/resource/server/deploy/Deployer.java
+++ b/src/main/java/iudx/resource/server/deploy/Deployer.java
@@ -100,7 +100,7 @@ public class Deployer {
                 .setEmbeddedServerOptions(new HttpServerOptions().setPort(9000)))
         // .setPublishQuantiles(true))
         .setLabels(EnumSet.of(Label.EB_ADDRESS, Label.EB_FAILURE, Label.HTTP_CODE,
-            Label.HTTP_METHOD, Label.HTTP_PATH))
+            Label.HTTP_METHOD))
         .setEnabled(true);
   }
 


### PR DESCRIPTION
- For each path query a metric series generated.
- Hence, this can potentially cause lot of metric series to be generated
due to lot of query paths (valid or invalid) - either through crawlers,
pentest, which would lead to overwhelming of prometheus.