### PR TITLE
Updated to refer configs archived for release 3.5.0 in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,7 @@ pipeline {
           script{
             startZap ([host: 'localhost', port: 8090, zapHome: '/var/lib/jenkins/tools/com.cloudbees.jenkins.plugins.customtools.CustomTool/OWASP_ZAP/ZAP_2.11.0'])
             sh 'curl http://127.0.0.1:8090/JSON/pscan/action/disableScanners/?ids=10096'
-            sh 'HTTP_PROXY=\'127.0.0.1:8090\' newman run /var/lib/jenkins/iudx/rs/Newman/IUDX-Resource-Server-Consumer-APIs-V3.5.postman_collection_new.json -e /home/ubuntu/configs/rs-postman-env.json --insecure -r htmlextra --reporter-htmlextra-export /var/lib/jenkins/iudx/rs/Newman/report/report.html --reporter-htmlextra-skipSensitiveData'
+            sh 'HTTP_PROXY=\'127.0.0.1:8090\' newman run /var/lib/jenkins/iudx/rs/Newman/IUDX-Resource-Server-Consumer-APIs-V3.5.postman_collection_new.json -e /home/ubuntu/configs/3.5.0/rs-postman-env.json --insecure -r htmlextra --reporter-htmlextra-export /var/lib/jenkins/iudx/rs/Newman/report/report.html --reporter-htmlextra-skipSensitiveData'
             runZapAttack()
           }
         }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,17 +8,16 @@ services:
   test:
     image: ghcr.io/datakaveri/rs-test:latest
     env_file:
-      - /home/ubuntu/configs/.rs.env
+      - /home/ubuntu/configs/3.5.0/.rs.env
     volumes:
       - ./src/:/usr/share/app/src
-      - /home/ubuntu/configs/rs-config-test.json:/usr/share/app/configs/config-test.json
-      - /home/ubuntu/configs/keystore.jks:/usr/share/app/configs/keystore.jks
+      - /home/ubuntu/configs/3.5.0/rs-config-test.json:/usr/share/app/configs/config-test.json
+      - /home/ubuntu/configs/3.5.0/keystore.jks:/usr/share/app/configs/keystore.jks
       - ./docker/runTests.sh:/usr/share/app/docker/runTests.sh
       - ${WORKSPACE}:/tmp/test
       - type: volume
         source: rs-volume
         target: /usr/share/app/storage/temp-dir
-
 
     command: bash -c "docker/runTests.sh"
     networks: 
@@ -32,10 +31,10 @@ services:
   perfTest:
     image: ghcr.io/datakaveri/rs-test:latest
     env_file:
-      - /home/ubuntu/configs/.rs.env
+      - /home/ubuntu/configs/3.5.0/.rs.env
     volumes:
-      - /home/ubuntu/configs/rs-config-dev.json:/usr/share/app/configs/config-dev.json
-      - /home/ubuntu/configs/keystore-rs.jks:/usr/share/app/configs/keystore.jks
+      - /home/ubuntu/configs/3.5.0/rs-config-dev.json:/usr/share/app/configs/config-dev.json
+      - /home/ubuntu/configs/3.5.0/keystore-rs.jks:/usr/share/app/configs/keystore.jks
       - ./src:/usr/share/app/src
       - type: volume
         source: rs-volume


### PR DESCRIPTION
Until now the same config files were being used in all the pipelines (master/PR/3.5.0). But since testing the v4.0 components (master and PR CI) might require changes in the config files, it could end up affecting v3.5.0 CI pipelines.
To avoid this, archiving the current configs for the 3.5.0 pipelines separately and updated references in the CI tests to refer to those.