### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,25 +10,25 @@
 		<vertx.version>4.3.2</vertx.version>
 		<openjdk.version>11</openjdk.version>
 		<hazelcast.version>4.0.2</hazelcast.version>
-		<micrometer.version>1.6.2</micrometer.version>
-		<curator.version>5.1.0</curator.version>
+		<micrometer.version>1.9.2</micrometer.version>
+		<curator.version>5.3.0</curator.version>
 		<apache-commons-lang3.version>3.12.0</apache-commons-lang3.version>
-		<junit-jupiter-engine.version>5.7.1</junit-jupiter-engine.version>
+		<junit-jupiter-engine.version>5.8.2</junit-jupiter-engine.version>
 		<apache-log4j2.version>2.17.1</apache-log4j2.version>
 		<lmax-disruptor.version>3.4.4</lmax-disruptor.version>
-		<jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
-		<checkstyle.version>8.42</checkstyle.version>
-		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-		<maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
-		<maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
-		<exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-		<maven-pmd-plugin.version>3.14.0</maven-pmd-plugin.version>
+		<jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
+		<checkstyle.version>10.3.1</checkstyle.version>
+		<maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+		<maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
+		<maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>
+		<exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
+		<maven-pmd-plugin.version>3.17.0</maven-pmd-plugin.version>
 		<maven-checkstyle-plugin-google.version>3.1.2</maven-checkstyle-plugin-google.version>
-		<maven-surefire-report-plugin.version>3.0.0-M5</maven-surefire-report-plugin.version>
-		<junit-jupiter.params>5.5.2</junit-jupiter.params>
-		<testcontainer.params>1.17.2</testcontainer.params>
-		<testcontainer-postgres.version>1.16.3</testcontainer-postgres.version>
-		<jts2geojson.version>0.16.1</jts2geojson.version>
+		<maven-surefire-report-plugin.version>3.0.0-M7</maven-surefire-report-plugin.version>
+		<junit-jupiter.params>5.8.2</junit-jupiter.params>
+		<testcontainer.params>1.17.3</testcontainer.params>
+		<testcontainer-postgres.version>1.17.3</testcontainer-postgres.version>
+		<jts2geojson.version>0.17.0</jts2geojson.version>
 		<elasticsearch-rest-client.version>7.12.1</elasticsearch-rest-client.version>
 		<elasticsearch-rest-high-level-client.version>7.12.1</elasticsearch-rest-high-level-client.version>
 		<!-- <flyway.plugin.version>7.11.1</flyway.plugin.version> -->
@@ -89,7 +89,6 @@
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-jdbc-client</artifactId>
-			<version>4.1.1</version>
 		</dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<version>0.0.1-SNAPSHOT</version>
 
 	<properties>
-		<vertx.version>4.0.3</vertx.version>
+		<vertx.version>4.3.2</vertx.version>
 		<openjdk.version>11</openjdk.version>
 		<hazelcast.version>4.0.2</hazelcast.version>
 		<micrometer.version>1.6.2</micrometer.version>

--- a/src/main/java/iudx/resource/server/apiserver/ManagementRestApi.java
+++ b/src/main/java/iudx/resource/server/apiserver/ManagementRestApi.java
@@ -51,6 +51,11 @@ import iudx.resource.server.database.postgres.PostgresService;
 import iudx.resource.server.databroker.DataBrokerService;
 import iudx.resource.server.metering.MeteringService;
 
+/**
+ * Since no one is using management API, these API endpoints will be deleted.
+ */
+
+@Deprecated
 public class ManagementRestApi {
 
 

--- a/src/main/java/iudx/resource/server/common/Constants.java
+++ b/src/main/java/iudx/resource/server/common/Constants.java
@@ -10,6 +10,7 @@ public class Constants {
   public static final String ASYNC_SERVICE_ADDRESS = "iudx.rs.async.service";
   public static final String DATABASE_SERVICE_ADDRESS = "iudx.rs.database.service";
   public static final String BROKER_SERVICE_ADDRESS = "iudx.rs.broker.service";
+  public static final String METERING_SERVICE_ADDRESS = "iudx.rs.metering.service";
 
 
 

--- a/src/main/java/iudx/resource/server/database/latest/RedisClient.java
+++ b/src/main/java/iudx/resource/server/database/latest/RedisClient.java
@@ -24,8 +24,7 @@ public class RedisClient {
   private RedisAPI redis;
   private Vertx vertx;
   private JsonObject config;
-//  private static final Command JSONGET =
-//      Command.create("JSON.GET", -1, 1, 1, 1, false, true, false, false);
+  private static final Command JSONGET = Command.create("JSON.GET");
   private static final Logger LOGGER = LogManager.getLogger(RedisClient.class);
 
 
@@ -120,7 +119,7 @@ public class RedisClient {
 
   public Future<JsonObject> get(String key, String path) {
     Promise<JsonObject> promise = Promise.promise();
-    redis.send(Command.JSON_GET, key, path).onFailure(res -> {
+    redis.send(JSONGET, key, path).onFailure(res -> {
       promise.fail(String.format("JSONGET did not work: %s", res.getMessage()));
     }).onSuccess(redisResponse -> {
       if (redisResponse == null) {

--- a/src/main/java/iudx/resource/server/database/latest/RedisClient.java
+++ b/src/main/java/iudx/resource/server/database/latest/RedisClient.java
@@ -24,10 +24,7 @@ public class RedisClient {
   private RedisAPI redis;
   private Vertx vertx;
   private JsonObject config;
-  private static final Command JSONGET = Command.create("JSON.GET");
   private static final Logger LOGGER = LogManager.getLogger(RedisClient.class);
-
-
 
   /**
    * RedisClient - Redis vertx Client Low Level Wrapper
@@ -119,7 +116,7 @@ public class RedisClient {
 
   public Future<JsonObject> get(String key, String path) {
     Promise<JsonObject> promise = Promise.promise();
-    redis.send(JSONGET, key, path).onFailure(res -> {
+    redis.send(Command.JSON_GET, key, path).onFailure(res -> {
       promise.fail(String.format("JSONGET did not work: %s", res.getMessage()));
     }).onSuccess(redisResponse -> {
       if (redisResponse == null) {

--- a/src/main/java/iudx/resource/server/database/latest/RedisClient.java
+++ b/src/main/java/iudx/resource/server/database/latest/RedisClient.java
@@ -24,8 +24,8 @@ public class RedisClient {
   private RedisAPI redis;
   private Vertx vertx;
   private JsonObject config;
-  private static final Command JSONGET =
-      Command.create("JSON.GET", -1, 1, 1, 1, false, true, false, false);
+//  private static final Command JSONGET =
+//      Command.create("JSON.GET", -1, 1, 1, 1, false, true, false, false);
   private static final Logger LOGGER = LogManager.getLogger(RedisClient.class);
 
 
@@ -120,7 +120,7 @@ public class RedisClient {
 
   public Future<JsonObject> get(String key, String path) {
     Promise<JsonObject> promise = Promise.promise();
-    redis.send(JSONGET, key, path).onFailure(res -> {
+    redis.send(Command.JSON_GET, key, path).onFailure(res -> {
       promise.fail(String.format("JSONGET did not work: %s", res.getMessage()));
     }).onSuccess(redisResponse -> {
       if (redisResponse == null) {


### PR DESCRIPTION
#### Dependencies/lib updates to latest stable releases

1.  Vertx version bump to 4.3.2 from 4.0.3
      -  Requires changing `context.getBodyAsJson()` to `context.body().asJsonObject()`
      -  `mountSubRouter` used is deprecated and requires using `subRouter`
      -  Redis command changes 
2.  Dependencies upgraded to latest stable release

| dependency | old version | new version |
|:---:|---|---|
| micrometer | 1.6.2 | 1.9.2 |
| curator | 5.1.0 | 5.3.0 |
| junit-jupiter-engine | 5.7.2 | 5.8.2 |
| junit-jupiter-params | 5.7.2 | 5.8.2 |
| testcontainer | 1.15.3 | 1.17.3 |
| testcontainer-postgres | 1.15.3 | 1.17.3 |
| jacoco | 0.8.7 | 0.8.8 |
| checkstyle(puppycrawl) | 8.4.2 | 10.3.1 |
| shade plugin | 3.2.4 | 3.3.0 |
| javadocs plugin | 3.2.0 | 3.4.0 |
| exec plugin | 3.0.0 | 3.1.0 |
| surefire pluigin | 3.0.0-M5 | 3.0.0-M7 |
| mvn compile plugin | 3.8.1 | 3.10.1 |
| pmd plugin | 3.14.0 | 3.17.0 |
| surefire-plugin | 3.0.0-M5 | 3.0.0-M7 |