### PR TITLE
3.5.0: Removal of unused config options in RS

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -341,8 +341,6 @@ In order to connect to the DX catalogue server, required information such as cat
     "authServerHost": <auth-server-host>,
     "catServerHost": <catalogue-server-host>,
     "catServerPort": <catalogue-server-port>,
-    "resourceServerId": [[<resource-server-id>]],
-    "serverMode": <server-mode>,
     "jwtIgnoreExpiry": <true | false>
 }
 ```
@@ -355,7 +353,6 @@ In order to connect to the DX catalogue server, required information such as cat
     "ssl": true,
     "keystore": <path/to/keystore.jks>,
     "keystorePassword": <password-for-keystore>,
-    "rsAdmin": <resource-server-admin>,
     "httpPort": <port-to-listen>,
     "verticleInstances": <number-of-verticle-instances>,
     "catServerHost": <catalogue-server-host>,
@@ -379,8 +376,6 @@ In order to connect to the DX authentication server, required information such a
     "authServerHost": <auth-server-host>,
     "catServerHost": <catalogue-server-host>,
     "catServerPort": <catalogue-server-port>,
-    "resourceServerId": [[<resource-server-id>]],
-    "serverMode": <server-mode>,
     "jwtIgnoreExpiry": <true | false>
 }
 ```

--- a/configs/config-depl.json
+++ b/configs/config-depl.json
@@ -11,7 +11,6 @@
             "databasePort": 123,
             "dbUser": "",
             "dbPassword": "",
-            "resourceServerId":"",
             "timeLimit": ""
         },
         {
@@ -27,8 +26,6 @@
             "testResourceID": "",
             "catServerHost": "",
             "catServerPort": "",
-            "serverMode": "production",
-            "resourceServerId":"",
 	    "jwtIgnoreExpiry": false
 
         },
@@ -87,7 +84,6 @@
 	    "httpPort": 8443,
             "keystore": "configs/keystore.jks",
             "keystorePassword": "",
-            "rsAdmin": "",
             "verticleInstances": 2,
             "catServerHost": "",
             "catServerPort": ""

--- a/configs/config-depl.json
+++ b/configs/config-depl.json
@@ -93,7 +93,6 @@
             "id": "iudx.resource.server.database.latest.LatestVerticle",
             "isWorkerVerticle":false,
             "verticleInstances": 2,
-            "attributeList": {"itms-info": "some-attr"},
             "redisMode": "CLUSTER",
             "redisUsername": "",
             "redisPassword": "",

--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -23,8 +23,6 @@
             "authServerHost": "",
             "catServerHost": "",
             "catServerPort": 443,
-            "resourceServerId": "",
-            "serverMode": "",
 	    "jwtIgnoreExpiry": true
 
         },
@@ -87,7 +85,6 @@
             "ssl": true,
             "keystore": "configs/keystore.jks",
             "keystorePassword": "",
-            "rsAdmin": "",
 	    "httpPort": 8443,
             "verticleInstances": 8,
             "catServerHost": "",

--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -94,7 +94,6 @@
            "id": "iudx.resource.server.database.latest.LatestVerticle",
            "isWorkerVerticle":false,
             "verticleInstances": 2,
-            "attributeList": {"itms-info": "some-attr"},
             "redisMode": "",
             "redisUsername": "",
             "redisPassword": "",

--- a/configs/config-example.json
+++ b/configs/config-example.json
@@ -23,8 +23,6 @@
             "authServerHost": "",
             "catServerHost": "",
             "catServerPort": 443,
-            "resourceServerId": "",
-            "serverMode": "production",
 	    "jwtIgnoreExpiry": false
         },
         {
@@ -87,7 +85,6 @@
             "keystore": "",
             "keystorePassword": "",
 	    "httpPort" : 8080,
-            "rsAdmin": "",
             "verticleInstances": 8,
             "catServerHost": "",
             "catServerPort": 123

--- a/configs/config-example.json
+++ b/configs/config-example.json
@@ -101,10 +101,7 @@
             "redisMaxWaitingHandlers": 1024,
             "redisPoolRecycleTimeout": 1500,
             "redisHost": "",
-            "redisPort": 1234,
-            "attributeList": {
-                "key": "value"
-            }
+            "redisPort": 1234
         },
         {
             "id": "iudx.resource.server.metering.MeteringVerticle",

--- a/configs/config-test.json
+++ b/configs/config-test.json
@@ -124,10 +124,7 @@
 			"redisMaxWaitingHandlers": 1024,
 			"redisPoolRecycleTimeout": 1500,
 			"redisHost": "",
-			"redisPort": 123,
-			"attributeList": {
-				"key": "value"
-			}
+			"redisPort": 123
 		},
 		{
 			"id": "iudx.resource.server.metering.MeteringVerticle",

--- a/configs/config-test.json
+++ b/configs/config-test.json
@@ -13,7 +13,6 @@
 			"databasePort": 12345,
 			"dbUser": "",
 			"dbPassword": "",
-			"resourceServerId": "",
 			"timeLimit": "",
 			"testIdOpen": "",
 			"testIdSecure": "",
@@ -33,8 +32,6 @@
 			"testResourceID": "",
 			"catServerHost": "",
 			"catServerPort": "",
-			"serverMode": "",
-			"resourceServerId": "",
 			"jwtIgnoreExpiry": true
 		},
 		{
@@ -100,7 +97,6 @@
 			"httpPort": 8443,
 			"keystore": "",
 			"keystorePassword": "",
-			"rsAdmin": "",
 			"verticleInstances": 2,
 			"authToken": "authtest.iudx.io/kailash.adhikari@india.nec.com/732b94a17b9e127d0541af9f3c9c9ef8",
 			"invalidauthToken": "",

--- a/src/main/java/iudx/resource/server/authenticator/Constants.java
+++ b/src/main/java/iudx/resource/server/authenticator/Constants.java
@@ -33,7 +33,6 @@ public class Constants {
   public static final ChronoUnit TIP_CACHE_TIMEOUT_UNIT = ChronoUnit.MINUTES;
   public static final String CAT_RSG_PATH = "/iudx/cat/v1/search";
   public static final String CAT_ITEM_PATH = "/iudx/cat/v1/item";
-  public static final String SERVER_MODE = "serverMode";
   public static final String JSON_USERID = "userid";
   public static final String JSON_IID = "iid";
   public static final String JSON_CONSUMER = "consumer";


### PR DESCRIPTION
- removal of  'resourceServerId',  'rsAdmin' as
grep -rnw src/ -e 'resourceServerId',
grep -rnw src/ -e 'rsAdmin' yields no result
- removal of 'serverMode' in constants as its not used anywhere
and subsequently the config option.
- Backport  #288 to 3.5.0 branch