### PR TITLE
Bug-fix: worker verticle configuration setting

### DIFF
--- a/src/main/java/iudx/resource/server/deploy/Deployer.java
+++ b/src/main/java/iudx/resource/server/deploy/Deployer.java
@@ -126,10 +126,20 @@ public class Deployer {
       LOGGER.fatal("Failed to deploy " + moduleName + " cause: Not Found");
       return;
     }
-
     int numInstances = config.getInteger("verticleInstances");
-    vertx.deployVerticle(moduleName,
-        new DeploymentOptions().setInstances(numInstances).setConfig(config), ar -> {
+    DeploymentOptions deploymentOptions =
+        new DeploymentOptions().setInstances(numInstances).setConfig(config);
+    boolean isWorkerVerticle = config.getBoolean("isWorkerVerticle");
+    if (isWorkerVerticle) {
+      LOGGER.info("worker verticle : " + config.getString("id"));
+      deploymentOptions.setWorkerPoolName(config.getString("threadPoolName"));
+      deploymentOptions.setWorkerPoolSize(config.getInteger("threadPoolSize"));
+      deploymentOptions.setWorker(true);
+      deploymentOptions.setMaxWorkerExecuteTime(30L);
+      deploymentOptions.setMaxWorkerExecuteTimeUnit(TimeUnit.MINUTES);
+    }
+
+    vertx.deployVerticle(moduleName, deploymentOptions, ar -> {
           if (ar.succeeded()) {
             LOGGER.info("Deployed " + moduleName);
             modules.remove(0);


### PR DESCRIPTION
- The recursiveDeploy method is overloaded in Deployer.java
- The one with three arguments is used to deployed custom set of modules/verticles. eg: just one verticle from config instead of all. Useful in K8s, as one (type of ) verticle (not verticle instance) is deployed in one pod.