### PR TITLE
4.0.0: Update openjdk, maven docker image

### DIFF
--- a/docker/depl.dockerfile
+++ b/docker/depl.dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION="0.0.1-SNAPSHOT"
 
 # Using maven base image in builder stage to build Java code.
-FROM maven:3-openjdk-11-slim as builder
+FROM maven:3-eclipse-temurin-11 as builder
 
 WORKDIR /usr/share/app
 COPY pom.xml .
@@ -12,7 +12,7 @@ COPY src src
 RUN mvn clean package -Dmaven.test.skip=true
 
 # Java Runtime as the base for final image
-FROM openjdk:11-jre-slim-buster
+FROM eclipse-temurin:11-jre-focal
 
 ARG VERSION
 ENV JAR="iudx.resource.server-cluster-${VERSION}-fat.jar"

--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION="0.0.1-SNAPSHOT"
 
 # Using maven base image in builder stage to build Java code.
-FROM maven:3-openjdk-11-slim as builder
+FROM maven:3-eclipse-temurin-11 as builder
 
 WORKDIR /usr/share/app
 COPY pom.xml .
@@ -12,7 +12,7 @@ COPY src src
 RUN mvn clean package -Dmaven.test.skip=true
 
 # Java Runtime as the base for final image
-FROM openjdk:11-jre-slim-buster
+FROM eclipse-temurin:11-jre-focal
 
 ARG VERSION
 ENV JAR="iudx.resource.server-dev-${VERSION}-fat.jar"

--- a/docker/test.dockerfile
+++ b/docker/test.dockerfile
@@ -2,7 +2,7 @@
 
 ARG VERSION="0.0.1-SNAPSHOT"
 
-FROM maven:latest as dependencies
+FROM maven:3-eclipse-temurin-11 as dependencies
 
 WORKDIR /usr/share/app
 COPY pom.xml .


### PR DESCRIPTION
- Updated openjdk, maven docker image with eclipse-temurin
- The openjdk image is officially deprecated - https://hub.docker.com/_/openjdk
- Hence, migrated base image to Eclipse-temurin - https://hub.docker.com/_/eclipse-temurin, maintained by https://github.com/adoptium/containers
- Back porting #331 change to 4.0.0 