### PR TITLE
ADD HEADER_OPTIONS in allowed headers for subs api

### DIFF
--- a/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
@@ -144,6 +144,7 @@ public class ApiServerVerticle extends AbstractVerticle {
         allowedHeaders.add(HEADER_REFERER);
         allowedHeaders.add(HEADER_ALLOW_ORIGIN);
         allowedHeaders.add(HEADER_PUBLIC_KEY);
+        allowedHeaders.add(HEADER_OPTIONS);
 
         Set<HttpMethod> allowedMethods = new HashSet<>();
         allowedMethods.add(HttpMethod.GET);


### PR DESCRIPTION
- HEADER_OPTIONS is used in subscription and needs to be allowed in CORS to make request from UI
- Currently it gives error
```
Request header field options is not allowed by
Access-Control-Allow-Headers in preflight response
```