### PR TITLE
try : fix query timeout to 180s

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,6 @@
         <testcontainer-postgres.version>1.17.3</testcontainer-postgres.version>
         <jts2geojson.version>0.17.0</jts2geojson.version>
         <elasticsearch-rest-client.version>8.3.3</elasticsearch-rest-client.version>
-        <!--<elasticsearch-rest-high-level-client.version>7.17.4</elasticsearch-rest-high-level-client.version>-->
-        <!-- <flyway.plugin.version>7.11.1</flyway.plugin.version> -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <exec.mainClass>iudx.resource.server.deploy.Deployer</exec.mainClass>
         <exec.mainClassDev>iudx.resource.server.deploy.DeployerDev

--- a/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
@@ -36,6 +36,7 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.CorsHandler;
+import io.vertx.ext.web.handler.TimeoutHandler;
 import iudx.resource.server.apiserver.exceptions.DxRuntimeException;
 import iudx.resource.server.apiserver.handlers.AuthHandler;
 import iudx.resource.server.apiserver.handlers.FailureHandler;
@@ -203,7 +204,7 @@ public class ApiServerVerticle extends AbstractVerticle {
         });
 
         router.route().handler(BodyHandler.create());
-
+        router.route().handler(TimeoutHandler.create(10000, 508));
         ValidatorsHandlersFactory validators = new ValidatorsHandlersFactory();
         FailureHandler validationsFailureHandler = new FailureHandler();
 

--- a/src/main/java/iudx/resource/server/database/elastic/ElasticClient.java
+++ b/src/main/java/iudx/resource/server/database/elastic/ElasticClient.java
@@ -170,7 +170,7 @@ public class ElasticClient {
       SourceConfig sourceFilterConfig) {
     Promise<JsonObject> promise = Promise.promise();
     SearchRequest searchRequest = SearchRequest
-        .of(e -> e.index(index).query(query).size(size).from(from).source(sourceFilterConfig));
+        .of(e -> e.index(index).query(query).size(size).from(from).source(sourceFilterConfig).timeout("180s"));
 
     asyncClient.search(searchRequest, ObjectNode.class).whenCompleteAsync((response, exception) -> {
       if (exception != null) {
@@ -213,7 +213,7 @@ public class ElasticClient {
     Promise<JsonObject> promise = Promise.promise();
     CountRequest countRequest = CountRequest.of(e -> e.index(index).query(query));
 
-    asyncClient.count(e -> e.index(index).query(query)).whenCompleteAsync((response, exception) -> {
+    asyncClient.count(countRequest).whenCompleteAsync((response, exception) -> {
       if (exception != null) {
         LOGGER.error("async count query failed : {}", exception);
         promise.fail(exception);


### PR DESCRIPTION
- Elastic query timeout set to 180s
- API request timeout is set to 10000ms(10s), if backend handlers don't return the result within 10s request will timeout for API client. 