### PR TITLE
[issue-368]: Make Catalogue Server, AAA Server basepaths configurable

### DIFF
--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -5,7 +5,9 @@
     ],
     "clusterId": "iudx-rs-cluster",
     "commonConfig" : {
-        "dxApiBasePath" : "/ngsi-ld/v1"
+        "dxApiBasePath" : "/ngsi-ld/v1",
+        "dxCatalogueBasePath": "/iudx/cat/v1",
+        "dxAuthBasePath": "/auth/v1"
     },
     "modules": [
         {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -32,7 +32,9 @@ info:
     - **Base path**:
       - Base path is the path on which API is served, relative to the host
       - It is the initial part of the API
-      - The base path value could be configured according to the deployment
+      - These base path values could be configured according to the deployment
+      - The base path for [DX AAA Server](https://github.com/datakaveri/iudx-aaa-server) is set to `/auth/v1`
+      - The base path for [DX Catalogue Server](https://github.com/datakaveri/iudx-catalogue-server) is set to `/iudx/cat/v1`
       - Currently, the following APIs have `/ngsi-ld/v1` base path
           -  /entities
           -  /temporal/entities

--- a/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
@@ -423,7 +423,7 @@ public class ApiServerVerticle extends AbstractVerticle {
 
         managementApi = new ManagementApiImpl();
         subsService = new SubscriptionService();
-        catalogueService = new CatalogueService(vertx, config(), api);
+        catalogueService = new CatalogueService(vertx, config());
         validator = new ParamsValidator(catalogueService);
 
         postgresService = PostgresService.createProxy(vertx, PG_SERVICE_ADDRESS);

--- a/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
@@ -122,8 +122,8 @@ public class ApiServerVerticle extends AbstractVerticle {
     private ParamsValidator validator;
     private EncryptionService encryptionService;
     private String dxApiBasePath;
-    String dxCatalogueBasePath;
-    String dxAuthBasePath;
+    private String dxCatalogueBasePath;
+    private String dxAuthBasePath;
     private Api api;
     private LatestDataService latestDataService;
 
@@ -165,7 +165,7 @@ public class ApiServerVerticle extends AbstractVerticle {
         dxApiBasePath = config().getString("dxApiBasePath");
         dxCatalogueBasePath = config().getString("dxCatalogueBasePath");
         dxAuthBasePath = config().getString("dxAuthBasePath");
-        api = Api.getInstance(dxApiBasePath,dxCatalogueBasePath,dxAuthBasePath);
+        api = Api.getInstance(dxApiBasePath);
 
         /* Define the APIs, methods, endpoints and associated methods. */
 

--- a/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
@@ -124,6 +124,7 @@ public class ApiServerVerticle extends AbstractVerticle {
     private String dxApiBasePath;
     private String dxCatalogueBasePath;
     private String dxAuthBasePath;
+
     private Api api;
     private LatestDataService latestDataService;
 

--- a/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
@@ -122,6 +122,8 @@ public class ApiServerVerticle extends AbstractVerticle {
     private ParamsValidator validator;
     private EncryptionService encryptionService;
     private String dxApiBasePath;
+    String dxCatalogueBasePath;
+    String dxAuthBasePath;
     private Api api;
     private LatestDataService latestDataService;
 
@@ -159,9 +161,11 @@ public class ApiServerVerticle extends AbstractVerticle {
 
         router = Router.router(vertx);
 
-        /* Get base path from config */
+        /* Get base paths from config */
         dxApiBasePath = config().getString("dxApiBasePath");
-        api = Api.getInstance(dxApiBasePath);
+        dxCatalogueBasePath = config().getString("dxCatalogueBasePath");
+        dxAuthBasePath = config().getString("dxAuthBasePath");
+        api = Api.getInstance(dxApiBasePath,dxCatalogueBasePath,dxAuthBasePath);
 
         /* Define the APIs, methods, endpoints and associated methods. */
 
@@ -419,7 +423,7 @@ public class ApiServerVerticle extends AbstractVerticle {
 
         managementApi = new ManagementApiImpl();
         subsService = new SubscriptionService();
-        catalogueService = new CatalogueService(vertx, config());
+        catalogueService = new CatalogueService(vertx, config(), api);
         validator = new ParamsValidator(catalogueService);
 
         postgresService = PostgresService.createProxy(vertx, PG_SERVICE_ADDRESS);

--- a/src/main/java/iudx/resource/server/apiserver/AsyncRestApi.java
+++ b/src/main/java/iudx/resource/server/apiserver/AsyncRestApi.java
@@ -69,7 +69,7 @@ public class AsyncRestApi{
     this.router=router;
     this.databroker = DataBrokerService.createProxy(vertx, BROKER_SERVICE_ADDRESS);
     this.meteringService = MeteringService.createProxy(vertx, METERING_SERVICE_ADDRESS);
-    this.catalogueService = new CatalogueService(vertx, config, api);
+    this.catalogueService = new CatalogueService(vertx, config);
     this.validator = new ParamsValidator(catalogueService);
     this.postgresService = PostgresService.createProxy(vertx, PG_SERVICE_ADDRESS);
     this.encryptionService = EncryptionService.createProxy(vertx, ENCRYPTION_SERVICE_ADDRESS);

--- a/src/main/java/iudx/resource/server/apiserver/AsyncRestApi.java
+++ b/src/main/java/iudx/resource/server/apiserver/AsyncRestApi.java
@@ -69,7 +69,7 @@ public class AsyncRestApi{
     this.router=router;
     this.databroker = DataBrokerService.createProxy(vertx, BROKER_SERVICE_ADDRESS);
     this.meteringService = MeteringService.createProxy(vertx, METERING_SERVICE_ADDRESS);
-    this.catalogueService = new CatalogueService(vertx, config);
+    this.catalogueService = new CatalogueService(vertx, config, api);
     this.validator = new ParamsValidator(catalogueService);
     this.postgresService = PostgresService.createProxy(vertx, PG_SERVICE_ADDRESS);
     this.encryptionService = EncryptionService.createProxy(vertx, ENCRYPTION_SERVICE_ADDRESS);

--- a/src/main/java/iudx/resource/server/apiserver/service/CatalogueService.java
+++ b/src/main/java/iudx/resource/server/apiserver/service/CatalogueService.java
@@ -41,20 +41,19 @@ public class CatalogueService {
   private static String catHost;
   private static int catPort;;
   private Vertx vertx;
-  private Api api;
   private String catBasePath;
   private String catItemPath;
   private final Cache<String, List<String>> applicableFilterCache =
       CacheBuilder.newBuilder().maximumSize(1000)
           .expireAfterAccess(Constants.CACHE_TIMEOUT_AMOUNT, TimeUnit.MINUTES).build();
 
-  public CatalogueService(Vertx vertx, JsonObject config, Api api) {
+  public CatalogueService(Vertx vertx, JsonObject config) {
     this.vertx = vertx;
     catHost = config.getString("catServerHost");
     catPort = config.getInteger("catServerPort");
     catBasePath = config.getString("dxCatalogueBasePath");
     catItemPath = catBasePath + CAT_ITEM_PATH;
-    this.api = api;
+
 
     WebClientOptions options =
         new WebClientOptions().setTrustAll(true).setVerifyHost(false).setSsl(true);

--- a/src/main/java/iudx/resource/server/apiserver/service/CatalogueService.java
+++ b/src/main/java/iudx/resource/server/apiserver/service/CatalogueService.java
@@ -43,6 +43,7 @@ public class CatalogueService {
   private Vertx vertx;
   private String catBasePath;
   private String catItemPath;
+  private String catSearchPath;
   private final Cache<String, List<String>> applicableFilterCache =
       CacheBuilder.newBuilder().maximumSize(1000)
           .expireAfterAccess(Constants.CACHE_TIMEOUT_AMOUNT, TimeUnit.MINUTES).build();
@@ -53,6 +54,7 @@ public class CatalogueService {
     catPort = config.getInteger("catServerPort");
     catBasePath = config.getString("dxCatalogueBasePath");
     catItemPath = catBasePath + CAT_ITEM_PATH;
+    catSearchPath = catBasePath + CAT_SEARCH_PATH;
 
 
     WebClientOptions options =
@@ -74,7 +76,7 @@ public class CatalogueService {
    */
   private Future<Boolean> populateCache() {
     Promise<Boolean> promise = Promise.promise();
-    catWebClient.get(catPort, catHost, catItemPath)
+    catWebClient.get(catPort, catHost, catSearchPath)
         .addQueryParam("property", "[iudxResourceAPIs]")
         .addQueryParam("value", "[[TEMPORAL,ATTR,SPATIAL]]")
         .addQueryParam("filter", "[iudxResourceAPIs,id]").expect(ResponsePredicate.JSON)

--- a/src/main/java/iudx/resource/server/apiserver/service/CatalogueService.java
+++ b/src/main/java/iudx/resource/server/apiserver/service/CatalogueService.java
@@ -44,6 +44,7 @@ public class CatalogueService {
   private String catBasePath;
   private String catItemPath;
   private String catSearchPath;
+
   private final Cache<String, List<String>> applicableFilterCache =
       CacheBuilder.newBuilder().maximumSize(1000)
           .expireAfterAccess(Constants.CACHE_TIMEOUT_AMOUNT, TimeUnit.MINUTES).build();
@@ -55,6 +56,7 @@ public class CatalogueService {
     catBasePath = config.getString("dxCatalogueBasePath");
     catItemPath = catBasePath + CAT_ITEM_PATH;
     catSearchPath = catBasePath + CAT_SEARCH_PATH;
+
 
 
     WebClientOptions options =

--- a/src/main/java/iudx/resource/server/authenticator/AuthenticationVerticle.java
+++ b/src/main/java/iudx/resource/server/authenticator/AuthenticationVerticle.java
@@ -47,7 +47,8 @@ public class AuthenticationVerticle extends AbstractVerticle {
   private MeteringService meteringService;
   private Api api;
   private String dxApiBasePath;
-
+  private String dxCatalogueBasePath;
+  private String dxAuthBasePath;
     static WebClient createWebClient(Vertx vertx, JsonObject config) {
     return createWebClient(vertx, config, false);
   }
@@ -96,7 +97,9 @@ public class AuthenticationVerticle extends AbstractVerticle {
               cacheService = CacheService.createProxy(vertx, CACHE_SERVICE_ADDRESS);
               meteringService = MeteringService.createProxy(vertx, METERING_SERVICE_ADDRESS);
               dxApiBasePath = config().getString("dxApiBasePath");
-              api = Api.getInstance(dxApiBasePath);
+              dxCatalogueBasePath = config().getString("dxCatalogueBasePath");
+              dxAuthBasePath = config().getString("dxAuthBasePath");
+              api = Api.getInstance(dxApiBasePath,dxCatalogueBasePath,dxAuthBasePath);
               jwtAuthenticationService =
                   new JwtAuthenticationServiceImpl(
                       vertx, jwtAuth, createWebClient(vertx, config()), config(), cacheService,
@@ -126,7 +129,7 @@ public class AuthenticationVerticle extends AbstractVerticle {
     Promise<String> promise = Promise.promise();
     webClient = createWebClient(vertx, config);
     webClient
-        .get(443, config.getString("authServerHost"), "/auth/v1/cert")
+        .get(443, config.getString("authServerHost"), api.getAuthCertificatePath())
         .send(
             handler -> {
               if (handler.succeeded()) {

--- a/src/main/java/iudx/resource/server/authenticator/AuthenticationVerticle.java
+++ b/src/main/java/iudx/resource/server/authenticator/AuthenticationVerticle.java
@@ -1,5 +1,6 @@
 package iudx.resource.server.authenticator;
 
+import static iudx.resource.server.authenticator.Constants.AUTH_CERTIFICATE_PATH;
 import static iudx.resource.server.common.Constants.AUTH_SERVICE_ADDRESS;
 import static iudx.resource.server.common.Constants.CACHE_SERVICE_ADDRESS;
 import static iudx.resource.server.common.Constants.METERING_SERVICE_ADDRESS;
@@ -47,8 +48,6 @@ public class AuthenticationVerticle extends AbstractVerticle {
   private MeteringService meteringService;
   private Api api;
   private String dxApiBasePath;
-  private String dxCatalogueBasePath;
-  private String dxAuthBasePath;
     static WebClient createWebClient(Vertx vertx, JsonObject config) {
     return createWebClient(vertx, config, false);
   }
@@ -97,9 +96,7 @@ public class AuthenticationVerticle extends AbstractVerticle {
               cacheService = CacheService.createProxy(vertx, CACHE_SERVICE_ADDRESS);
               meteringService = MeteringService.createProxy(vertx, METERING_SERVICE_ADDRESS);
               dxApiBasePath = config().getString("dxApiBasePath");
-              dxCatalogueBasePath = config().getString("dxCatalogueBasePath");
-              dxAuthBasePath = config().getString("dxAuthBasePath");
-              api = Api.getInstance(dxApiBasePath,dxCatalogueBasePath,dxAuthBasePath);
+              api = Api.getInstance(dxApiBasePath);
               jwtAuthenticationService =
                   new JwtAuthenticationServiceImpl(
                       vertx, jwtAuth, createWebClient(vertx, config()), config(), cacheService,
@@ -128,8 +125,9 @@ public class AuthenticationVerticle extends AbstractVerticle {
   private Future<String> getJwtPublicKey(Vertx vertx, JsonObject config) {
     Promise<String> promise = Promise.promise();
     webClient = createWebClient(vertx, config);
+    String authCert = config.getString("dxAuthBasePath") + AUTH_CERTIFICATE_PATH;
     webClient
-        .get(443, config.getString("authServerHost"), api.getAuthCertificatePath())
+        .get(443, config.getString("authServerHost"), authCert)
         .send(
             handler -> {
               if (handler.succeeded()) {

--- a/src/main/java/iudx/resource/server/authenticator/Constants.java
+++ b/src/main/java/iudx/resource/server/authenticator/Constants.java
@@ -12,6 +12,8 @@ public class Constants {
   public static final String AUTH_SERVER_HOST = "authServerHost";
   public static final String AUTH_CERTINFO_PATH = "/auth/v1/certificate-info";
   public static final String PUBLIC_TOKEN = "public";
+
+  public static final String AUTH_CERTIFICATE_PATH = "/cert";
   public static final List<String> OPEN_ENDPOINTS =
       List.of(
           "/temporal/entities",
@@ -34,7 +36,8 @@ public class Constants {
   public static final long CACHE_TIMEOUT_AMOUNT = 30;
   public static final ChronoUnit TIP_CACHE_TIMEOUT_UNIT = ChronoUnit.MINUTES;
   public static final String CAT_RSG_PATH = "/iudx/cat/v1/search";
-  public static final String CAT_ITEM_PATH = "/iudx/cat/v1/item";
+  public static final String CAT_SEARCH_PATH = "/search";
+  public static final String CAT_ITEM_PATH = "/item";
   public static final String JSON_USERID = "userid";
   public static final String JSON_IID = "iid";
   public static final String JSON_CONSUMER = "consumer";

--- a/src/main/java/iudx/resource/server/authenticator/Constants.java
+++ b/src/main/java/iudx/resource/server/authenticator/Constants.java
@@ -35,7 +35,7 @@ public class Constants {
   public static final String MANAGEMENT_ENDPOINT = "/management/*";
   public static final long CACHE_TIMEOUT_AMOUNT = 30;
   public static final ChronoUnit TIP_CACHE_TIMEOUT_UNIT = ChronoUnit.MINUTES;
-  public static final String CAT_RSG_PATH = "/iudx/cat/v1/search";
+//  public static final String CAT_RSG_PATH = "/iudx/cat/v1/search";
   public static final String CAT_SEARCH_PATH = "/search";
   public static final String CAT_ITEM_PATH = "/item";
   public static final String JSON_USERID = "userid";

--- a/src/main/java/iudx/resource/server/authenticator/JwtAuthenticationServiceImpl.java
+++ b/src/main/java/iudx/resource/server/authenticator/JwtAuthenticationServiceImpl.java
@@ -53,6 +53,7 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
   final MeteringService meteringService;
   final boolean isLimitsEnabled;
   final Api apis;
+  final String catBasePath;
 
   // resourceGroupCache will contains ACL info about all resource group in a resource server
   Cache<String, String> resourceGroupCache =
@@ -76,7 +77,8 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
     this.audience = config.getString("audience");
     this.host = config.getString("catServerHost");
     this.port = config.getInteger("catServerPort");
-    this.path = Constants.CAT_RSG_PATH;
+    this.catBasePath = config.getString("dxCatalogueBasePath");
+    this.path = catBasePath + CAT_SEARCH_PATH;
     this.isLimitsEnabled =
         config.getBoolean("enableLimits") != null ? config.getBoolean("enableLimits") : false;
     this.apis = apis;
@@ -443,8 +445,9 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
     Promise<Boolean> promise = Promise.promise();
     String id = itemId.replace("/*", "");
     LOGGER.debug("id : " + id);
+    String catItemPath = catBasePath + CAT_ITEM_PATH;
     catWebClient
-        .get(port, host, apis.getCatItemPath())
+        .get(port, host, catItemPath)
         .addQueryParam("id", id)
         .expect(ResponsePredicate.JSON)
         .send(

--- a/src/main/java/iudx/resource/server/authenticator/JwtAuthenticationServiceImpl.java
+++ b/src/main/java/iudx/resource/server/authenticator/JwtAuthenticationServiceImpl.java
@@ -444,7 +444,7 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
     String id = itemId.replace("/*", "");
     LOGGER.debug("id : " + id);
     catWebClient
-        .get(port, host, "/iudx/cat/v1/item")
+        .get(port, host, apis.getCatItemPath())
         .addQueryParam("id", id)
         .expect(ResponsePredicate.JSON)
         .send(

--- a/src/main/java/iudx/resource/server/common/Api.java
+++ b/src/main/java/iudx/resource/server/common/Api.java
@@ -1,10 +1,13 @@
 package iudx.resource.server.common;
 
 import static iudx.resource.server.apiserver.util.Constants.*;
+import static iudx.resource.server.authenticator.Constants.*;
 
 public class Api {
 
     private final String dxApiBasePath;
+    private final String dxCatalogueBasePath;
+    private final String dxAuthBasePath;
     private StringBuilder entitiesUrl;
     private StringBuilder temporalUrl;
     private StringBuilder subscriptionUrl;
@@ -17,6 +20,9 @@ public class Api {
     private StringBuilder iudxManagementAdapterUrl;
     private StringBuilder ingestionPath;
     private StringBuilder resetPassword;
+    private StringBuilder catSearchPath;
+    private StringBuilder catItemPath;
+    private StringBuilder authCertificatePath;
 
     private StringBuilder asyncPath;
 
@@ -25,14 +31,16 @@ public class Api {
 
 
 
-    private Api(String dxApiBasePath) {
+    private Api(String dxApiBasePath, String dxCatalogueBasePath, String dxAuthBasePath) {
         this.dxApiBasePath = dxApiBasePath;
+        this.dxCatalogueBasePath = dxCatalogueBasePath;
+        this.dxAuthBasePath = dxAuthBasePath;
         buildPaths();
     }
 
 
 
-    public static Api getInstance(String dxApiBasePath)
+    public static Api getInstance(String dxApiBasePath, String dxCatalogueBasePath, String dxAuthBasePath)
     {
         if(apiInstance == null)
         {
@@ -40,7 +48,7 @@ public class Api {
             {
                 if(apiInstance == null)
                 {
-                    apiInstance = new Api(dxApiBasePath);
+                    apiInstance = new Api(dxApiBasePath, dxCatalogueBasePath, dxAuthBasePath);
                 }
             }
         }
@@ -61,7 +69,9 @@ public class Api {
         asyncPath = new StringBuilder(dxApiBasePath).append(ASYNC);
         iudxAsyncStatusApi = new StringBuilder(dxApiBasePath).append(ASYNC + STATUS);
         resetPassword = new StringBuilder(dxApiBasePath).append(RESET_PWD);
-
+        catItemPath = new StringBuilder(dxCatalogueBasePath).append(CAT_ITEM_PATH);
+        catSearchPath = new StringBuilder(dxCatalogueBasePath).append(CAT_SEARCH_PATH);
+        authCertificatePath = new StringBuilder(dxAuthBasePath).append(AUTH_CERTIFICATE_PATH);
     }
 
     public String getEntitiesUrl() {
@@ -121,5 +131,18 @@ public class Api {
     public String getManagementBasePath()
     {
         return resetPassword.toString();
+    }
+
+    public String getCatItemPath(){
+        return catItemPath.toString();
+    }
+    public String getCatSearchPath()
+    {
+        return catSearchPath.toString();
+    }
+
+    public String getAuthCertificatePath()
+    {
+        return authCertificatePath.toString();
     }
 }

--- a/src/main/java/iudx/resource/server/common/Api.java
+++ b/src/main/java/iudx/resource/server/common/Api.java
@@ -1,13 +1,10 @@
 package iudx.resource.server.common;
 
 import static iudx.resource.server.apiserver.util.Constants.*;
-import static iudx.resource.server.authenticator.Constants.*;
 
 public class Api {
 
     private final String dxApiBasePath;
-    private final String dxCatalogueBasePath;
-    private final String dxAuthBasePath;
     private StringBuilder entitiesUrl;
     private StringBuilder temporalUrl;
     private StringBuilder subscriptionUrl;
@@ -20,9 +17,7 @@ public class Api {
     private StringBuilder iudxManagementAdapterUrl;
     private StringBuilder ingestionPath;
     private StringBuilder resetPassword;
-    private StringBuilder catSearchPath;
-    private StringBuilder catItemPath;
-    private StringBuilder authCertificatePath;
+
 
     private StringBuilder asyncPath;
 
@@ -31,16 +26,14 @@ public class Api {
 
 
 
-    private Api(String dxApiBasePath, String dxCatalogueBasePath, String dxAuthBasePath) {
+    private Api(String dxApiBasePath) {
         this.dxApiBasePath = dxApiBasePath;
-        this.dxCatalogueBasePath = dxCatalogueBasePath;
-        this.dxAuthBasePath = dxAuthBasePath;
         buildPaths();
     }
 
 
 
-    public static Api getInstance(String dxApiBasePath, String dxCatalogueBasePath, String dxAuthBasePath)
+    public static Api getInstance(String dxApiBasePath)
     {
         if(apiInstance == null)
         {
@@ -48,7 +41,7 @@ public class Api {
             {
                 if(apiInstance == null)
                 {
-                    apiInstance = new Api(dxApiBasePath, dxCatalogueBasePath, dxAuthBasePath);
+                    apiInstance = new Api(dxApiBasePath);
                 }
             }
         }
@@ -69,9 +62,6 @@ public class Api {
         asyncPath = new StringBuilder(dxApiBasePath).append(ASYNC);
         iudxAsyncStatusApi = new StringBuilder(dxApiBasePath).append(ASYNC + STATUS);
         resetPassword = new StringBuilder(dxApiBasePath).append(RESET_PWD);
-        catItemPath = new StringBuilder(dxCatalogueBasePath).append(CAT_ITEM_PATH);
-        catSearchPath = new StringBuilder(dxCatalogueBasePath).append(CAT_SEARCH_PATH);
-        authCertificatePath = new StringBuilder(dxAuthBasePath).append(AUTH_CERTIFICATE_PATH);
     }
 
     public String getEntitiesUrl() {
@@ -133,16 +123,4 @@ public class Api {
         return resetPassword.toString();
     }
 
-    public String getCatItemPath(){
-        return catItemPath.toString();
-    }
-    public String getCatSearchPath()
-    {
-        return catSearchPath.toString();
-    }
-
-    public String getAuthCertificatePath()
-    {
-        return authCertificatePath.toString();
-    }
 }

--- a/src/main/java/iudx/resource/server/common/Api.java
+++ b/src/main/java/iudx/resource/server/common/Api.java
@@ -1,6 +1,7 @@
 package iudx.resource.server.common;
 
 import static iudx.resource.server.apiserver.util.Constants.*;
+import static iudx.resource.server.authenticator.Constants.*;
 
 public class Api {
 
@@ -17,6 +18,7 @@ public class Api {
     private StringBuilder iudxManagementAdapterUrl;
     private StringBuilder ingestionPath;
     private StringBuilder resetPassword;
+
 
 
     private StringBuilder asyncPath;
@@ -128,5 +130,6 @@ public class Api {
 
     public String getMonthlyOverview(){
         return monthlyOverview.toString();
+
     }
 }

--- a/src/main/java/iudx/resource/server/common/Api.java
+++ b/src/main/java/iudx/resource/server/common/Api.java
@@ -1,7 +1,6 @@
 package iudx.resource.server.common;
 
 import static iudx.resource.server.apiserver.util.Constants.*;
-import static iudx.resource.server.authenticator.Constants.*;
 
 public class Api {
 

--- a/src/test/java/iudx/resource/server/apiserver/handlers/AuthHandlerTest.java
+++ b/src/test/java/iudx/resource/server/apiserver/handlers/AuthHandlerTest.java
@@ -69,6 +69,8 @@ public class AuthHandlerTest {
   AuthHandler authHandler;
   JsonObject jsonObject;
   private static String dxApiBasePath;
+  private static String dxCatalogueBasePath;
+  private static String dxAuthBasePath;
   private static Api apis;
   @BeforeEach
   public void setUp(VertxTestContext vertxTestContext) {
@@ -82,14 +84,19 @@ public class AuthHandlerTest {
     lenient().when(httpMethod.toString()).thenReturn("GET");
     lenient().when(routingContext.request()).thenReturn(httpServerRequest);
     dxApiBasePath = jsonObject.getString("dxApiBasePath");
-    apis = Api.getInstance(dxApiBasePath);
+    dxApiBasePath = "/ngsi-ld/v1";
+    dxCatalogueBasePath = "/iudx/cat/v1";
+    dxAuthBasePath = "/auth/v1";
+    apis = Api.getInstance(dxApiBasePath, dxCatalogueBasePath, dxAuthBasePath);
     authHandler = AuthHandler.create(Vertx.vertx(),apis);
     vertxTestContext.completeNow();
   }
 
   public static Stream<Arguments> urls() {
     dxApiBasePath = "/ngsi-ld/v1";
-    apis = Api.getInstance(dxApiBasePath);
+    dxCatalogueBasePath = "/iudx/cat/v1";
+    dxAuthBasePath = "/auth/v1";
+    apis = Api.getInstance(dxApiBasePath, dxCatalogueBasePath, dxAuthBasePath);
     return Stream.of(
 
         Arguments.of(Constants.EXCHANGE_URL_REGEX, IUDX_MANAGEMENT_URL + EXCHANGE_PATH + "(.*)"),

--- a/src/test/java/iudx/resource/server/apiserver/handlers/AuthHandlerTest.java
+++ b/src/test/java/iudx/resource/server/apiserver/handlers/AuthHandlerTest.java
@@ -85,6 +85,7 @@ public class AuthHandlerTest {
     dxApiBasePath = jsonObject.getString("dxApiBasePath");
     dxApiBasePath = "/ngsi-ld/v1";
     apis = Api.getInstance(dxApiBasePath);
+
     authHandler = AuthHandler.create(Vertx.vertx(),apis);
     vertxTestContext.completeNow();
   }

--- a/src/test/java/iudx/resource/server/apiserver/handlers/AuthHandlerTest.java
+++ b/src/test/java/iudx/resource/server/apiserver/handlers/AuthHandlerTest.java
@@ -69,8 +69,7 @@ public class AuthHandlerTest {
   AuthHandler authHandler;
   JsonObject jsonObject;
   private static String dxApiBasePath;
-  private static String dxCatalogueBasePath;
-  private static String dxAuthBasePath;
+
   private static Api apis;
   @BeforeEach
   public void setUp(VertxTestContext vertxTestContext) {
@@ -85,18 +84,14 @@ public class AuthHandlerTest {
     lenient().when(routingContext.request()).thenReturn(httpServerRequest);
     dxApiBasePath = jsonObject.getString("dxApiBasePath");
     dxApiBasePath = "/ngsi-ld/v1";
-    dxCatalogueBasePath = "/iudx/cat/v1";
-    dxAuthBasePath = "/auth/v1";
-    apis = Api.getInstance(dxApiBasePath, dxCatalogueBasePath, dxAuthBasePath);
+    apis = Api.getInstance(dxApiBasePath);
     authHandler = AuthHandler.create(Vertx.vertx(),apis);
     vertxTestContext.completeNow();
   }
 
   public static Stream<Arguments> urls() {
     dxApiBasePath = "/ngsi-ld/v1";
-    dxCatalogueBasePath = "/iudx/cat/v1";
-    dxAuthBasePath = "/auth/v1";
-    apis = Api.getInstance(dxApiBasePath, dxCatalogueBasePath, dxAuthBasePath);
+    apis = Api.getInstance(dxApiBasePath);
     return Stream.of(
 
         Arguments.of(Constants.EXCHANGE_URL_REGEX, IUDX_MANAGEMENT_URL + EXCHANGE_PATH + "(.*)"),

--- a/src/test/java/iudx/resource/server/apiserver/service/CatalogueServiceTest.java
+++ b/src/test/java/iudx/resource/server/apiserver/service/CatalogueServiceTest.java
@@ -56,6 +56,9 @@ CatalogueService catalogueService;
         config = new JsonObject();
         config.put("catServerHost","guest");
         config.put("catServerPort",8443);
+        config.put("dxApiBasePath","/ngsi-ld/v1");
+        config.put("dxCatalogueBasePath","/iudx/cat/v1");
+        config.put("dxAuthBasePath","/auth/v1");
         JsonObject jsonObject = new JsonObject();
         JsonArray jsonArray = new JsonArray();
         JsonArray jsonArray1 = new JsonArray();
@@ -80,10 +83,8 @@ CatalogueService catalogueService;
                 return null;
             }
         }).when(httpRequest).send(any());
-        dxApiBasePath = "/ngsi-ld/v1";
-        dxCatalogueBasePath = "/iudx/cat/v1";
-        dxAuthBasePath = "/auth/v1";
-        Api api = Api.getInstance(dxApiBasePath, dxCatalogueBasePath, dxAuthBasePath);
+
+        Api api = Api.getInstance(dxApiBasePath);
         catalogueService = new CatalogueService(vertxObj,config, api);
         vertxTestContext.completeNow();
     }

--- a/src/test/java/iudx/resource/server/apiserver/service/CatalogueServiceTest.java
+++ b/src/test/java/iudx/resource/server/apiserver/service/CatalogueServiceTest.java
@@ -11,7 +11,6 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import iudx.resource.server.common.Api;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -84,8 +83,8 @@ CatalogueService catalogueService;
             }
         }).when(httpRequest).send(any());
 
-        Api api = Api.getInstance(dxApiBasePath);
-        catalogueService = new CatalogueService(vertxObj,config, api);
+
+        catalogueService = new CatalogueService(vertxObj,config);
         vertxTestContext.completeNow();
     }
 

--- a/src/test/java/iudx/resource/server/apiserver/service/CatalogueServiceTest.java
+++ b/src/test/java/iudx/resource/server/apiserver/service/CatalogueServiceTest.java
@@ -11,6 +11,7 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import iudx.resource.server.common.Api;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,9 @@ CatalogueService catalogueService;
     AsyncResult<HttpResponse<Buffer>> asyncResult;
     @Mock
     HttpResponse<Buffer> httpResponse;
-
+    String dxAuthBasePath;
+    String dxCatalogueBasePath;
+    String dxApiBasePath;
 
     @BeforeEach
     public void setUp(VertxTestContext vertxTestContext)
@@ -77,7 +80,11 @@ CatalogueService catalogueService;
                 return null;
             }
         }).when(httpRequest).send(any());
-        catalogueService = new CatalogueService(vertxObj,config);
+        dxApiBasePath = "/ngsi-ld/v1";
+        dxCatalogueBasePath = "/iudx/cat/v1";
+        dxAuthBasePath = "/auth/v1";
+        Api api = Api.getInstance(dxApiBasePath, dxCatalogueBasePath, dxAuthBasePath);
+        catalogueService = new CatalogueService(vertxObj,config, api);
         vertxTestContext.completeNow();
     }
 

--- a/src/test/java/iudx/resource/server/apiserver/service/CatalogueServiceTest.java
+++ b/src/test/java/iudx/resource/server/apiserver/service/CatalogueServiceTest.java
@@ -11,7 +11,6 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import iudx.resource.server.common.Api;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,9 +45,7 @@ CatalogueService catalogueService;
     AsyncResult<HttpResponse<Buffer>> asyncResult;
     @Mock
     HttpResponse<Buffer> httpResponse;
-    String dxAuthBasePath;
-    String dxCatalogueBasePath;
-    String dxApiBasePath;
+
 
     @BeforeEach
     public void setUp(VertxTestContext vertxTestContext)
@@ -56,9 +53,6 @@ CatalogueService catalogueService;
         config = new JsonObject();
         config.put("catServerHost","guest");
         config.put("catServerPort",8443);
-        config.put("dxApiBasePath","/ngsi-ld/v1");
-        config.put("dxCatalogueBasePath","/iudx/cat/v1");
-        config.put("dxAuthBasePath","/auth/v1");
         JsonObject jsonObject = new JsonObject();
         JsonArray jsonArray = new JsonArray();
         JsonArray jsonArray1 = new JsonArray();
@@ -83,17 +77,7 @@ CatalogueService catalogueService;
                 return null;
             }
         }).when(httpRequest).send(any());
-<<<<<<< HEAD
-
-
         catalogueService = new CatalogueService(vertxObj,config);
-=======
-        dxApiBasePath = "/ngsi-ld/v1";
-        dxCatalogueBasePath = "/iudx/cat/v1";
-        dxAuthBasePath = "/auth/v1";
-        Api api = Api.getInstance(dxApiBasePath, dxCatalogueBasePath, dxAuthBasePath);
-        catalogueService = new CatalogueService(vertxObj,config, api);
->>>>>>> 03cd305 ([issue-368]: make basepath configurable)
         vertxTestContext.completeNow();
     }
 

--- a/src/test/java/iudx/resource/server/apiserver/service/CatalogueServiceTest.java
+++ b/src/test/java/iudx/resource/server/apiserver/service/CatalogueServiceTest.java
@@ -77,6 +77,8 @@ CatalogueService catalogueService;
                 return null;
             }
         }).when(httpRequest).send(any());
+
+
         catalogueService = new CatalogueService(vertxObj,config);
         vertxTestContext.completeNow();
     }

--- a/src/test/java/iudx/resource/server/apiserver/service/CatalogueServiceTest.java
+++ b/src/test/java/iudx/resource/server/apiserver/service/CatalogueServiceTest.java
@@ -11,6 +11,7 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import iudx.resource.server.common.Api;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -82,9 +83,17 @@ CatalogueService catalogueService;
                 return null;
             }
         }).when(httpRequest).send(any());
+<<<<<<< HEAD
 
 
         catalogueService = new CatalogueService(vertxObj,config);
+=======
+        dxApiBasePath = "/ngsi-ld/v1";
+        dxCatalogueBasePath = "/iudx/cat/v1";
+        dxAuthBasePath = "/auth/v1";
+        Api api = Api.getInstance(dxApiBasePath, dxCatalogueBasePath, dxAuthBasePath);
+        catalogueService = new CatalogueService(vertxObj,config, api);
+>>>>>>> 03cd305 ([issue-368]: make basepath configurable)
         vertxTestContext.completeNow();
     }
 

--- a/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceImplTest.java
+++ b/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceImplTest.java
@@ -70,9 +70,8 @@ public class JwtAuthServiceImplTest {
   private static CacheService cacheService;
   private static MeteringService meteringService;
   private static Api apis;
-  private static String dxApiBasePath;
-  private static String dxCatalogueBasePath;
-  private static String dxAuthBasePath;
+
+
 
   @BeforeAll
   @DisplayName("Initialize Vertx and deploy Auth Verticle")
@@ -83,7 +82,7 @@ public class JwtAuthServiceImplTest {
     authConfig.put("dxCatalogueBasePath", "/iudx/cat/v1");
     authConfig.put("dxAuthBasePath", "/auth/v1");
 
-    apis = Api.getInstance(dxApiBasePath);
+    apis = Api.getInstance("/ngsi-ld/v1");
     JWTAuthOptions jwtAuthOptions = new JWTAuthOptions();
     jwtAuthOptions.addPubSecKey(
             new PubSecKeyOptions()

--- a/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceImplTest.java
+++ b/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceImplTest.java
@@ -71,7 +71,8 @@ public class JwtAuthServiceImplTest {
   private static MeteringService meteringService;
   private static Api apis;
   private static String dxApiBasePath;
-
+  private static String dxCatalogueBasePath;
+  private static String dxAuthBasePath;
 
   @BeforeAll
   @DisplayName("Initialize Vertx and deploy Auth Verticle")
@@ -81,7 +82,9 @@ public class JwtAuthServiceImplTest {
     authConfig.put("dxApiBasePath","/ngsi-ld/v1");
 
     dxApiBasePath = "/ngsi-ld/v1";
-    apis = Api.getInstance(dxApiBasePath);
+    dxCatalogueBasePath = "/iudx/cat/v1";
+    dxAuthBasePath = "/auth/v1";
+    apis = Api.getInstance(dxApiBasePath, dxCatalogueBasePath, dxAuthBasePath);
     JWTAuthOptions jwtAuthOptions = new JWTAuthOptions();
     jwtAuthOptions.addPubSecKey(
             new PubSecKeyOptions()

--- a/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceImplTest.java
+++ b/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceImplTest.java
@@ -73,6 +73,7 @@ public class JwtAuthServiceImplTest {
 
 
 
+
   @BeforeAll
   @DisplayName("Initialize Vertx and deploy Auth Verticle")
   static void init(Vertx vertx, VertxTestContext testContext) {

--- a/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceImplTest.java
+++ b/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceImplTest.java
@@ -80,11 +80,10 @@ public class JwtAuthServiceImplTest {
     config = new Configuration();
     authConfig = config.configLoader(1, vertx);
     authConfig.put("dxApiBasePath","/ngsi-ld/v1");
+    authConfig.put("dxCatalogueBasePath", "/iudx/cat/v1");
+    authConfig.put("dxAuthBasePath", "/auth/v1");
 
-    dxApiBasePath = "/ngsi-ld/v1";
-    dxCatalogueBasePath = "/iudx/cat/v1";
-    dxAuthBasePath = "/auth/v1";
-    apis = Api.getInstance(dxApiBasePath, dxCatalogueBasePath, dxAuthBasePath);
+    apis = Api.getInstance(dxApiBasePath);
     JWTAuthOptions jwtAuthOptions = new JWTAuthOptions();
     jwtAuthOptions.addPubSecKey(
             new PubSecKeyOptions()

--- a/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceTest.java
+++ b/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceTest.java
@@ -51,6 +51,8 @@ public class JwtAuthServiceTest {
     JwtAuthenticationServiceImpl jwtAuthenticationService;
     private Api apis;
     private String dxApiBasePath;
+    private String dxCatalogueBasePath;
+    private String dxAuthBasePath;
 
     @BeforeEach
     public void setUp(VertxTestContext vertxTestContext)
@@ -58,7 +60,9 @@ public class JwtAuthServiceTest {
         JWTAuthOptions jwtAuthOptions = new JWTAuthOptions();
 //        jwtAuthenticationService.jwtDecodeFuture = mock(Future.class);
         dxApiBasePath = "/ngsi-ld/v1";
-        apis = Api.getInstance(dxApiBasePath);
+        dxCatalogueBasePath = "/iudx/cat/v1";
+        dxAuthBasePath = "/auth/v1";
+        apis = Api.getInstance(dxApiBasePath, dxCatalogueBasePath, dxAuthBasePath);
         jwtAuthOptions.addPubSecKey(
                 new PubSecKeyOptions()
                         .setAlgorithm("ES256")

--- a/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceTest.java
+++ b/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceTest.java
@@ -62,7 +62,7 @@ public class JwtAuthServiceTest {
         dxApiBasePath = "/ngsi-ld/v1";
         dxCatalogueBasePath = "/iudx/cat/v1";
         dxAuthBasePath = "/auth/v1";
-        apis = Api.getInstance(dxApiBasePath, dxCatalogueBasePath, dxAuthBasePath);
+        apis = Api.getInstance(dxApiBasePath);
         jwtAuthOptions.addPubSecKey(
                 new PubSecKeyOptions()
                         .setAlgorithm("ES256")

--- a/src/test/resources/IUDX-Resource-Server-Consumer-APIs (v3.5.0).postman_collection.json
+++ b/src/test/resources/IUDX-Resource-Server-Consumer-APIs (v3.5.0).postman_collection.json
@@ -73,7 +73,7 @@
 							}
 						},
 						"url": {
-							"raw": "https://authvertx.iudx.io/auth/v1/token",
+							"raw": "https://authvertx.iudx.io/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"authvertx",
@@ -81,8 +81,7 @@
 								"io"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -154,7 +153,7 @@
 							}
 						},
 						"url": {
-							"raw": "https://authvertx.iudx.io/auth/v1/token",
+							"raw": "https://authvertx.iudx.io/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"authvertx",
@@ -162,8 +161,7 @@
 								"io"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -235,7 +233,7 @@
 							}
 						},
 						"url": {
-							"raw": "https://authvertx.iudx.io/auth/v1/token",
+							"raw": "https://authvertx.iudx.io/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"authvertx",
@@ -243,8 +241,7 @@
 								"io"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -316,7 +313,7 @@
 							}
 						},
 						"url": {
-							"raw": "https://authvertx.iudx.io/auth/v1/token",
+							"raw": "https://authvertx.iudx.io/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"authvertx",
@@ -324,8 +321,7 @@
 								"io"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}

--- a/src/test/resources/IUDX-Resource-Server-Consumer-APIs-V3.5.postman_collection.json
+++ b/src/test/resources/IUDX-Resource-Server-Consumer-APIs-V3.5.postman_collection.json
@@ -47,14 +47,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -114,14 +113,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}

--- a/src/test/resources/IUDX-Resource-Server-Consumer-APIs-V4.0.environment.json
+++ b/src/test/resources/IUDX-Resource-Server-Consumer-APIs-V4.0.environment.json
@@ -13,6 +13,11 @@
 			"enabled": true
 		},
 		{
+			"key": "dxAuthBasePath",
+			"value": "auth/v1",
+			"enabled": true
+		},
+		{
 			"key": "openResourceToken",
 			"value": "",
 			"type": "default",

--- a/src/test/resources/IUDX-Resource-Server-Consumer-APIs-V4.0.postman_collection.json
+++ b/src/test/resources/IUDX-Resource-Server-Consumer-APIs-V4.0.postman_collection.json
@@ -47,14 +47,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -114,14 +113,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -192,7 +190,7 @@
 							}
 						},
 						"url": {
-							"raw": "https://authvertx.iudx.io/auth/v1/token",
+							"raw": "https://authvertx.iudx.io/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"authvertx",
@@ -200,8 +198,7 @@
 								"io"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -272,7 +269,7 @@
 							}
 						},
 						"url": {
-							"raw": "https://authvertx.iudx.io/auth/v1/token",
+							"raw": "https://authvertx.iudx.io/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"authvertx",
@@ -280,8 +277,7 @@
 								"io"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -352,7 +348,7 @@
 							}
 						},
 						"url": {
-							"raw": "https://authvertx.iudx.io/auth/v1/token",
+							"raw": "https://authvertx.iudx.io/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"authvertx",
@@ -360,8 +356,7 @@
 								"io"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -432,7 +427,7 @@
 							}
 						},
 						"url": {
-							"raw": "https://authvertx.iudx.io/auth/v1/token",
+							"raw": "https://authvertx.iudx.io/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"authvertx",
@@ -440,8 +435,7 @@
 								"io"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}

--- a/src/test/resources/README.md
+++ b/src/test/resources/README.md
@@ -1,8 +1,8 @@
 ### Making configurable base path
 - Base path can be added in postman environment file or in postman.
-- `IUDX-Resource-Server-Consumer-APIs-V4.0.environment.json` has **values** array which has a fields named **basePath** whose **value** is currently set to `ngsi-ld/v1`.
-- The **value** could be changed according to the deployment and then the collection with the `IUDX-Resource-Server-Consumer-APIs-V4.0.environment.json` file can be uploaded to Postman
-- For the changing the **basePath** value in postman after importing the collection and environment files, locate `RS Environment` from **Environments** in sidebar of Postman application.
+- `IUDX-Resource-Server-Consumer-APIs-V4.0.environment.json` has **values** array which has a fields named **basePath** whose **value** is currently set to `ngsi-ld/v1`, **dxAuthBasePath** with value `auth/v1`.
+- These value(s) could be changed according to the deployment and then the collection with the `IUDX-Resource-Server-Consumer-APIs-V4.0.environment.json` file can be uploaded to Postman
+- For the changing the **basePath**, **dxAuthBasePath** value in postman after importing the collection and environment files, locate `RS Environment` from **Environments** in sidebar of Postman application.
 - To know more about Postman environments, refer : [postman environments](https://learning.postman.com/docs/sending-requests/managing-environments/)
 - The **CURRENT VALUE** of the variable could be changed
 


### PR DESCRIPTION
Solved bug mentioned in the PR #368
Made the Catalogue Server, AAA Server base paths configurable by changing config-dev and other files

config-dev : 
```
 "commonConfig" : {
        "dxApiBasePath" : "/ngsi-ld/v1",
        "dxCatalogueBasePath": "/iudx/cat/v1",
        "dxAuthBasePath": "/auth/v1"
    }
```
postman-environment-file :
```
{
	"key": "dxAuthBasePath",
	"value": "auth/v1",
	"enabled": true
}
```
