### PR TITLE
Catalogue cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
           sh 'scp Jmeter/ResourceServer.jmx jenkins@jenkins-master:/var/lib/jenkins/iudx/rs/Jmeter/'
           sh 'scp src/test/resources/IUDX-Resource-Server-Consumer-APIs-V4.0.postman_collection.json jenkins@jenkins-master:/var/lib/jenkins/iudx/rs/Newman/'
           sh 'docker-compose -f docker-compose.test.yml up -d perfTest'
-          sh 'sleep 45'
+          sh 'sleep 180'
         }
       }
       post{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
           sh 'scp Jmeter/ResourceServer.jmx jenkins@jenkins-master:/var/lib/jenkins/iudx/rs/Jmeter/'
           sh 'scp src/test/resources/IUDX-Resource-Server-Consumer-APIs-V4.0.postman_collection.json jenkins@jenkins-master:/var/lib/jenkins/iudx/rs/Newman/'
           sh 'docker-compose -f docker-compose.test.yml up -d perfTest'
-          sh 'sleep 180'
+          sh 'sleep 120'
         }
       }
       post{

--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -112,6 +112,8 @@
         {
             "id": "iudx.resource.server.cache.CacheVerticle",
             "isWorkerVerticle":false,
+            "catServerHost": "cat-api",
+            "catServerPort": 123,
             "verticleInstances": 1
         },
         {

--- a/configs/config-example.json
+++ b/configs/config-example.json
@@ -108,6 +108,8 @@
         {
             "id": "iudx.resource.server.cache.CacheVerticle",
             "isWorkerVerticle":false,
+            "catServerHost": "cat-api",
+            "catServerPort": 123,
             "verticleInstances": 1
         },
         {

--- a/configs/config-test.json
+++ b/configs/config-test.json
@@ -130,6 +130,8 @@
 		{
 			"id": "iudx.resource.server.cache.CacheVerticle",
 			"isWorkerVerticle":false,
+			"catServerHost": "cat-api",
+            "catServerPort": 123,
 			"verticleInstances": 1
 		},
 		{

--- a/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
@@ -214,7 +214,7 @@ public class ApiServerVerticle extends AbstractVerticle {
         });
         
         router.route().handler(BodyHandler.create());
-        router.route().handler(TimeoutHandler.create(10000, 408));
+        router.route().handler(TimeoutHandler.create(20000, 408));
         ValidatorsHandlersFactory validators = new ValidatorsHandlersFactory();
         FailureHandler validationsFailureHandler = new FailureHandler();
         /* NGSI-LD api endpoints */

--- a/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/resource/server/apiserver/ApiServerVerticle.java
@@ -214,7 +214,7 @@ public class ApiServerVerticle extends AbstractVerticle {
         });
         
         router.route().handler(BodyHandler.create());
-        router.route().handler(TimeoutHandler.create(20000, 408));
+        router.route().handler(TimeoutHandler.create(10000, 408));
         ValidatorsHandlersFactory validators = new ValidatorsHandlersFactory();
         FailureHandler validationsFailureHandler = new FailureHandler();
         /* NGSI-LD api endpoints */

--- a/src/main/java/iudx/resource/server/apiserver/AsyncRestApi.java
+++ b/src/main/java/iudx/resource/server/apiserver/AsyncRestApi.java
@@ -34,6 +34,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
+import iudx.resource.server.apiserver.exceptions.DxRuntimeException;
 import iudx.resource.server.apiserver.handlers.AuthHandler;
 import iudx.resource.server.apiserver.handlers.FailureHandler;
 import iudx.resource.server.apiserver.handlers.ValidationHandler;
@@ -50,7 +51,7 @@ import iudx.resource.server.database.postgres.PostgresService;
 import iudx.resource.server.databroker.DataBrokerService;
 import iudx.resource.server.metering.MeteringService;
 
-public class AsyncRestApi{
+public class AsyncRestApi {
 
   private static final Logger LOGGER = LogManager.getLogger(AsyncRestApi.class);
 
@@ -66,13 +67,13 @@ public class AsyncRestApi{
   private EncryptionService encryptionService;
   private Api api;
 
-  AsyncRestApi(Vertx vertx,Router router, JsonObject config, Api api) {
+  AsyncRestApi(Vertx vertx, Router router, JsonObject config, Api api) {
     this.vertx = vertx;
-    this.router=router;
+    this.router = router;
     this.databroker = DataBrokerService.createProxy(vertx, BROKER_SERVICE_ADDRESS);
     this.meteringService = MeteringService.createProxy(vertx, METERING_SERVICE_ADDRESS);
-    this.cacheService=CacheService.createProxy(vertx, CACHE_SERVICE_ADDRESS);
-    this.catalogueService = new CatalogueService(vertx, config,cacheService);
+    this.cacheService = CacheService.createProxy(vertx, CACHE_SERVICE_ADDRESS);
+    this.catalogueService = new CatalogueService(vertx, config, cacheService);
     this.validator = new ParamsValidator(catalogueService);
     this.postgresService = PostgresService.createProxy(vertx, PG_SERVICE_ADDRESS);
     this.encryptionService = EncryptionService.createProxy(vertx, ENCRYPTION_SERVICE_ADDRESS);
@@ -88,19 +89,19 @@ public class AsyncRestApi{
 
     ValidationHandler asyncSearchValidation = new ValidationHandler(vertx, ASYNC_SEARCH);
     router
-            .get(SEARCH)
-            .handler(asyncSearchValidation)
-            .handler(AuthHandler.create(vertx,api))
-            .handler(this::handleAsyncSearchRequest)
-            .failureHandler(validationsFailureHandler);
+        .get(SEARCH)
+          .handler(asyncSearchValidation)
+          .handler(AuthHandler.create(vertx, api))
+          .handler(this::handleAsyncSearchRequest)
+          .failureHandler(validationsFailureHandler);
 
     ValidationHandler asyncStatusValidation = new ValidationHandler(vertx, ASYNC_STATUS);
     router
-            .get(STATUS)
-            .handler(asyncStatusValidation)
-            .handler(AuthHandler.create(vertx,api))
-            .handler(this::handleAsyncStatusRequest)
-            .failureHandler(validationsFailureHandler);
+        .get(STATUS)
+          .handler(asyncStatusValidation)
+          .handler(AuthHandler.create(vertx, api))
+          .handler(this::handleAsyncStatusRequest)
+          .failureHandler(validationsFailureHandler);
 
     return this.router;
   }
@@ -112,100 +113,112 @@ public class AsyncRestApi{
 
     String instanceID = request.getHeader(HEADER_HOST);
     MultiMap params = getQueryParams(routingContext, response).get();
+
+    if (containsTemporalParams(params) && !isValidTemporalQuery(params, routingContext)) {
+      routingContext
+          .fail(400,
+              new DxRuntimeException(400, ResponseUrn.BAD_REQUEST_URN, "Invalid temporal query"));
+      return;
+    }
+
+    if (containsGeoParams(params) && !isValidGeoQuery(params, routingContext)) {
+      routingContext
+          .fail(400, new DxRuntimeException(400, ResponseUrn.BAD_REQUEST_URN, "Invalid geo query"));
+      return;
+    }
+
     Future<Boolean> validationResult = validator.validate(params);
-    validationResult.onComplete(
-            validationHandler -> {
-              if (validationHandler.succeeded()) {
-                NGSILDQueryParams ngsildquery = new NGSILDQueryParams(params);
-                QueryMapper queryMapper = new QueryMapper(routingContext);
-                JsonObject json = queryMapper.toJson(ngsildquery,
-                        ngsildquery.getTemporalRelation().getTemprel() != null, true);
-                Future<List<String>> filtersFuture =
-                        catalogueService.getApplicableFilters(json.getJsonArray("id").getString(0));
-                json.put(JSON_INSTANCEID, instanceID);
-                LOGGER.debug("Info: IUDX json query;" + json);
-                JsonObject requestBody = new JsonObject();
-                requestBody.put("ids", json.getJsonArray("id"));
-                filtersFuture.onComplete(
-                        filtersHandler -> {
-                          if (filtersHandler.succeeded()) {
-                            json.put("applicableFilters", filtersHandler.result());
-                            executeAsyncURLSearch(routingContext, json);
-                          } else {
-                            LOGGER.error("catalogue item/group doesn't have filters.");
-                          }
-                        });
-              } else if (validationHandler.failed()) {
-                LOGGER.error("Fail: Bad request;");
-                handleResponse(
-                        response, BAD_REQUEST, INVALID_PARAM_URN, validationHandler.cause().getMessage());
-              }
-            });
+    validationResult.onComplete(validationHandler -> {
+      if (validationHandler.succeeded()) {
+        NGSILDQueryParams ngsildquery = new NGSILDQueryParams(params);
+        QueryMapper queryMapper = new QueryMapper(routingContext);
+        JsonObject json = queryMapper.toJson(ngsildquery, true, true);
+        Future<List<String>> filtersFuture =
+            catalogueService.getApplicableFilters(json.getJsonArray("id").getString(0));
+        json.put(JSON_INSTANCEID, instanceID);
+        LOGGER.debug("Info: IUDX json query;" + json);
+        JsonObject requestBody = new JsonObject();
+        requestBody.put("ids", json.getJsonArray("id"));
+        filtersFuture.onComplete(filtersHandler -> {
+          if (filtersHandler.succeeded()) {
+            json.put("applicableFilters", filtersHandler.result());
+            executeAsyncURLSearch(routingContext, json);
+          } else {
+            LOGGER.error("catalogue item/group doesn't have filters.");
+          }
+        });
+      } else if (validationHandler.failed()) {
+        LOGGER.error("Fail: Bad request;");
+        handleResponse(response, BAD_REQUEST, INVALID_PARAM_URN,
+            validationHandler.cause().getMessage());
+      }
+    });
   }
 
   private void executeAsyncURLSearch(RoutingContext routingContext, JsonObject json) {
     String sub = ((JsonObject) routingContext.data().get("authInfo")).getString(USER_ID);
 
-    String requestId = Hashing.sha256()
-            .hashString(json.toString(), StandardCharsets.UTF_8)
-            .toString();
+    String requestId =
+        Hashing.sha256().hashString(json.toString(), StandardCharsets.UTF_8).toString();
 
     String searchId = UUID.randomUUID().toString();
 
-    StringBuilder insert_query =
-            new StringBuilder(INSERT_S3_PENDING_SQL.replace("$1", UUID.randomUUID().toString())
-                    .replace("$2", searchId)
-                    .replace("$3", requestId)
-                    .replace("$4", sub)
-                    .replace("$5", QueryProgress.SUBMITTED.toString())
-                    .replace("$6", String.valueOf(0.0))
-                    .replace("$7", json.toString()));
+    StringBuilder insert_query = new StringBuilder(INSERT_S3_PENDING_SQL
+        .replace("$1", UUID.randomUUID().toString())
+          .replace("$2", searchId)
+          .replace("$3", requestId)
+          .replace("$4", sub)
+          .replace("$5", QueryProgress.SUBMITTED.toString())
+          .replace("$6", String.valueOf(0.0))
+          .replace("$7", json.toString()));
 
     JsonObject rmqQueryMessage = new JsonObject()
-            .put("searchId", searchId)
-            .put("requestId", requestId)
-            .put("user", sub)
-            .put("query", json);
+        .put("searchId", searchId)
+          .put("requestId", requestId)
+          .put("user", sub)
+          .put("query", json);
 
-    postgresService
-            .executeQuery(insert_query.toString(), pgInsertHandler -> {
-              if (pgInsertHandler.succeeded()) {
-                databroker.publishMessage(rmqQueryMessage, "async-query", "#", rmqPublishHandler -> {
-                  if (rmqPublishHandler.succeeded()) {
-                    JsonObject response = new JsonObject();
-                    response.put(JSON_TYPE, ResponseUrn.SUCCESS_URN.getUrn());
-                    response.put(JSON_TITLE, "query submitted successfully");
-                    JsonArray resultArray = new JsonArray();
-                    resultArray.add(new JsonObject().put("searchId", searchId));
-                    response.put("result", resultArray);
-                    if (routingContext.request().getHeader(HEADER_PUBLIC_KEY) == null) {
-                      handleSuccessResponse(routingContext.response(), ResponseType.Created.getCode(),
-                              response.toString());
-                    }
-//            Encryption
-                    else {
-                      Future<JsonObject> future = encryption(routingContext, response.getJsonArray("result").toString());
-                      future.onComplete(encryptionHandler -> {
-                        if (encryptionHandler.succeeded()) {
-                          JsonObject result = encryptionHandler.result();
-                          response.put("result",result);
-                          handleSuccessResponse(routingContext.response(), ResponseType.Created.getCode(),
-                                  response.encode());
-                        } else {
-                          LOGGER.error("Encryption not completed: " + encryptionHandler.cause().getMessage());
-                          processBackendResponse(routingContext.response(), encryptionHandler.cause().getMessage());
-                        }
-                      });
-                    }
+    postgresService.executeQuery(insert_query.toString(), pgInsertHandler -> {
+      if (pgInsertHandler.succeeded()) {
+        databroker.publishMessage(rmqQueryMessage, "async-query", "#", rmqPublishHandler -> {
+          if (rmqPublishHandler.succeeded()) {
+            JsonObject response = new JsonObject();
+            response.put(JSON_TYPE, ResponseUrn.SUCCESS_URN.getUrn());
+            response.put(JSON_TITLE, "query submitted successfully");
+            JsonArray resultArray = new JsonArray();
+            resultArray.add(new JsonObject().put("searchId", searchId));
+            response.put("result", resultArray);
+            if (routingContext.request().getHeader(HEADER_PUBLIC_KEY) == null) {
+              handleSuccessResponse(routingContext.response(), ResponseType.Created.getCode(),
+                  response.toString());
+            }
+            // Encryption
+            else {
+              Future<JsonObject> future =
+                  encryption(routingContext, response.getJsonArray("result").toString());
+              future.onComplete(encryptionHandler -> {
+                if (encryptionHandler.succeeded()) {
+                  JsonObject result = encryptionHandler.result();
+                  response.put("result", result);
+                  handleSuccessResponse(routingContext.response(), ResponseType.Created.getCode(),
+                      response.encode());
+                } else {
+                  LOGGER
+                      .error("Encryption not completed: " + encryptionHandler.cause().getMessage());
+                  processBackendResponse(routingContext.response(),
+                      encryptionHandler.cause().getMessage());
+                }
+              });
+            }
 
-                  } else {
-                    LOGGER.error("message published failed", rmqPublishHandler);
-                  }
-                });
-              } else {
-                LOGGER.error("message save to postgres failed", pgInsertHandler);
-              }
-            });
+          } else {
+            LOGGER.error("message published failed", rmqPublishHandler);
+          }
+        });
+      } else {
+        LOGGER.error("message save to postgres failed", pgInsertHandler);
+      }
+    });
 
   }
 
@@ -224,14 +237,15 @@ public class AsyncRestApi{
         if (routingContext.request().getHeader(HEADER_PUBLIC_KEY) == null) {
           handleSuccessResponse(response, ResponseType.Ok.getCode(), handler.result().toString());
         }
-//        Encryption
+        // Encryption
         else {
-          Future<JsonObject> future = encryption(routingContext, handler.result().getJsonArray("results").toString());
+          Future<JsonObject> future =
+              encryption(routingContext, handler.result().getJsonArray("results").toString());
           future.onComplete(encryptionHandler -> {
             if (encryptionHandler.succeeded()) {
               JsonObject result = encryptionHandler.result();
-              handler.result().put("results",result);
-              handleSuccessResponse(response, ResponseType.Ok.getCode(),  handler.result().encode());
+              handler.result().put("results", result);
+              handleSuccessResponse(response, ResponseType.Ok.getCode(), handler.result().encode());
             } else {
               LOGGER.error("Encryption not completed: " + encryptionHandler.cause().getMessage());
               processBackendResponse(response, encryptionHandler.cause().getMessage());
@@ -244,21 +258,24 @@ public class AsyncRestApi{
       }
     });
   }
+
   /**
    * Encrypts the result of API response.
-   * @param context  Routing Context
-   * @param result  value of result param in the API response
-   * @return  encrypted data
+   * 
+   * @param context Routing Context
+   * @param result value of result param in the API response
+   * @return encrypted data
    */
   private Future<JsonObject> encryption(RoutingContext context, String result) {
     String URLbase64PublicKey = context.request().getHeader(HEADER_PUBLIC_KEY);
     Promise<JsonObject> promise = Promise.promise();
 
     /* get the urlbase64 public key from the header and send it for encryption */
-    Future<JsonObject> future = encryptionService.encrypt(result, new JsonObject().put(ENCODED_KEY, URLbase64PublicKey));
+    Future<JsonObject> future =
+        encryptionService.encrypt(result, new JsonObject().put(ENCODED_KEY, URLbase64PublicKey));
     future.onComplete(handler -> {
       if (handler.succeeded()) {
-        /*  get encoded cipher text */
+        /* get encoded cipher text */
         String encodedCipherText = handler.result().getString(ENCODED_CIPHER_TEXT);
         /* Send back the encoded cipherText to Client */
         final JsonObject jsonObject = new JsonObject();
@@ -271,6 +288,7 @@ public class AsyncRestApi{
     });
     return promise.future();
   }
+
   private void handleSuccessResponse(HttpServerResponse response, int statusCode, String result) {
     response.putHeader(CONTENT_TYPE, APPLICATION_JSON).setStatusCode(statusCode).end(result);
   }
@@ -291,33 +309,33 @@ public class AsyncRestApi{
       }
       // return urn in body
       response
-              .putHeader(CONTENT_TYPE, APPLICATION_JSON)
-              .setStatusCode(type)
-              .end(generateResponse(status, urn, detail).toString());
+          .putHeader(CONTENT_TYPE, APPLICATION_JSON)
+            .setStatusCode(type)
+            .end(generateResponse(status, urn, detail).toString());
     } catch (DecodeException ex) {
       LOGGER.error("ERROR : Expecting Json from backend service [ jsonFormattingException ]");
       handleResponse(response, BAD_REQUEST, BACKING_SERVICE_FORMAT_URN);
     }
   }
 
-  private Optional<MultiMap> getQueryParams(
-          RoutingContext routingContext, HttpServerResponse response) {
+  private Optional<MultiMap> getQueryParams(RoutingContext routingContext,
+      HttpServerResponse response) {
     MultiMap queryParams = null;
     try {
       queryParams = MultiMap.caseInsensitiveMultiMap();
       // Internally + sign is dropped and treated as space, replacing + with %2B do the trick
       String uri = routingContext.request().uri().replaceAll("\\+", "%2B");
       Map<String, List<String>> decodedParams =
-              new QueryStringDecoder(uri, HttpConstants.DEFAULT_CHARSET, true, 1024, true).parameters();
+          new QueryStringDecoder(uri, HttpConstants.DEFAULT_CHARSET, true, 1024, true).parameters();
       for (Map.Entry<String, List<String>> entry : decodedParams.entrySet()) {
         LOGGER.debug("Info: param :" + entry.getKey() + " value : " + entry.getValue());
         queryParams.add(entry.getKey(), entry.getValue());
       }
     } catch (IllegalArgumentException ex) {
       response
-              .putHeader(CONTENT_TYPE, APPLICATION_JSON)
-              .setStatusCode(BAD_REQUEST.getValue())
-              .end(generateResponse(BAD_REQUEST, INVALID_PARAM_URN).toString());
+          .putHeader(CONTENT_TYPE, APPLICATION_JSON)
+            .setStatusCode(BAD_REQUEST.getValue())
+            .end(generateResponse(BAD_REQUEST, INVALID_PARAM_URN).toString());
     }
     return Optional.of(queryParams);
   }
@@ -326,11 +344,32 @@ public class AsyncRestApi{
     handleResponse(response, code, urn, code.getDescription());
   }
 
-  private void handleResponse(
-          HttpServerResponse response, HttpStatusCode statusCode, ResponseUrn urn, String message) {
+  private void handleResponse(HttpServerResponse response, HttpStatusCode statusCode,
+      ResponseUrn urn, String message) {
     response
-            .putHeader(CONTENT_TYPE, APPLICATION_JSON)
-            .setStatusCode(statusCode.getValue())
-            .end(generateResponse(statusCode, urn, message).toString());
+        .putHeader(CONTENT_TYPE, APPLICATION_JSON)
+          .setStatusCode(statusCode.getValue())
+          .end(generateResponse(statusCode, urn, message).toString());
+  }
+
+  private boolean isValidTemporalQuery(MultiMap params, RoutingContext context) {
+    return params.contains(JSON_TIMEREL) && params.contains(JSON_TIME)
+        && params.contains(JSON_ENDTIME);
+  }
+
+  private boolean containsTemporalParams(MultiMap params) {
+    return params.contains(JSON_TIMEREL) || params.contains(JSON_TIME)
+        || params.contains(JSON_ENDTIME);
+  }
+
+
+  private boolean isValidGeoQuery(MultiMap params, RoutingContext context) {
+    return params.contains(JSON_GEOPROPERTY) && params.contains(JSON_GEOREL)
+        && params.contains(JSON_GEOMETRY) && params.contains(JSON_COORDINATES);
+  }
+
+  private boolean containsGeoParams(MultiMap params) {
+    return params.contains(JSON_GEOPROPERTY) || params.contains(JSON_GEOREL)
+        || params.contains(JSON_GEOMETRY) || params.contains(JSON_COORDINATES);
   }
 }

--- a/src/main/java/iudx/resource/server/apiserver/AsyncRestApi.java
+++ b/src/main/java/iudx/resource/server/apiserver/AsyncRestApi.java
@@ -41,6 +41,7 @@ import iudx.resource.server.apiserver.query.NGSILDQueryParams;
 import iudx.resource.server.apiserver.query.QueryMapper;
 import iudx.resource.server.apiserver.response.ResponseType;
 import iudx.resource.server.apiserver.service.CatalogueService;
+import iudx.resource.server.cache.CacheService;
 import iudx.resource.server.common.HttpStatusCode;
 import iudx.resource.server.common.ResponseUrn;
 import iudx.resource.server.database.async.AsyncService;
@@ -61,6 +62,7 @@ public class AsyncRestApi{
   private final CatalogueService catalogueService;
   private final PostgresService postgresService;
   private final DataBrokerService databroker;
+  private final CacheService cacheService;
   private EncryptionService encryptionService;
   private Api api;
 
@@ -69,7 +71,8 @@ public class AsyncRestApi{
     this.router=router;
     this.databroker = DataBrokerService.createProxy(vertx, BROKER_SERVICE_ADDRESS);
     this.meteringService = MeteringService.createProxy(vertx, METERING_SERVICE_ADDRESS);
-    this.catalogueService = new CatalogueService(vertx, config);
+    this.cacheService=CacheService.createProxy(vertx, CACHE_SERVICE_ADDRESS);
+    this.catalogueService = new CatalogueService(vertx, config,cacheService);
     this.validator = new ParamsValidator(catalogueService);
     this.postgresService = PostgresService.createProxy(vertx, PG_SERVICE_ADDRESS);
     this.encryptionService = EncryptionService.createProxy(vertx, ENCRYPTION_SERVICE_ADDRESS);

--- a/src/main/java/iudx/resource/server/apiserver/AsyncRestApi.java
+++ b/src/main/java/iudx/resource/server/apiserver/AsyncRestApi.java
@@ -117,7 +117,7 @@ public class AsyncRestApi{
             validationHandler -> {
               if (validationHandler.succeeded()) {
                 NGSILDQueryParams ngsildquery = new NGSILDQueryParams(params);
-                QueryMapper queryMapper = new QueryMapper();
+                QueryMapper queryMapper = new QueryMapper(routingContext);
                 JsonObject json = queryMapper.toJson(ngsildquery,
                         ngsildquery.getTemporalRelation().getTemprel() != null, true);
                 Future<List<String>> filtersFuture =

--- a/src/main/java/iudx/resource/server/apiserver/handlers/FailureHandler.java
+++ b/src/main/java/iudx/resource/server/apiserver/handlers/FailureHandler.java
@@ -18,7 +18,7 @@ public class FailureHandler implements Handler<RoutingContext> {
   @Override
   public void handle(RoutingContext context) {
     Throwable failure = context.failure();
-
+    LOGGER.debug("exception caught");
     if (failure instanceof DxRuntimeException) {
       DxRuntimeException exception = (DxRuntimeException) failure;
       LOGGER.error(exception.getUrn().getUrn() + " : " + exception.getMessage());
@@ -46,6 +46,12 @@ public class FailureHandler implements Handler<RoutingContext> {
           .end(validationFailureReponse(validationErrorMessage).toString());
 
     }
+    
+    if(context.response().ended()) {
+      LOGGER.debug("Already ended");
+      return;
+    }
+    
     context.next();
     return;
   }

--- a/src/main/java/iudx/resource/server/apiserver/query/QueryMapper.java
+++ b/src/main/java/iudx/resource/server/apiserver/query/QueryMapper.java
@@ -219,7 +219,7 @@ public class QueryMapper {
     if (isAttributeSearch) {
       searchType.append(Constants.JSON_ATTRIBUTE_SEARCH);
     }
-    return searchType.substring(0, searchType.length() - 1).toString();
+    return searchType.toString().isEmpty()?"": searchType.substring(0, searchType.length() - 1).toString();
   }
 
   JsonObject getQueryTerms(String queryTerms) {

--- a/src/main/java/iudx/resource/server/apiserver/service/CatalogueService.java
+++ b/src/main/java/iudx/resource/server/apiserver/service/CatalogueService.java
@@ -1,31 +1,16 @@
 package iudx.resource.server.apiserver.service;
 
 import static iudx.resource.server.apiserver.util.Util.toList;
-import static iudx.resource.server.authenticator.Constants.CAT_ITEM_PATH;
-import static iudx.resource.server.authenticator.Constants.CAT_SEARCH_PATH;
-
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import iudx.resource.server.common.Api;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.client.WebClientOptions;
-import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import iudx.resource.server.authenticator.Constants;
 import iudx.resource.server.cache.CacheService;
 import iudx.resource.server.cache.cacheImpl.CacheType;

--- a/src/main/java/iudx/resource/server/apiserver/service/CatalogueService.java
+++ b/src/main/java/iudx/resource/server/apiserver/service/CatalogueService.java
@@ -47,19 +47,29 @@ public class CatalogueService {
   private String catItemPath;
   private String catSearchPath;
 
-//  private final Cache<String, List<String>> applicableFilterCache =
-//      CacheBuilder.newBuilder().maximumSize(1000)
-//          .expireAfterAccess(Constants.CACHE_TIMEOUT_AMOUNT, TimeUnit.MINUTES).build();
-  
+  // private final Cache<String, List<String>> applicableFilterCache =
+  // CacheBuilder.newBuilder().maximumSize(1000)
+  // .expireAfterAccess(Constants.CACHE_TIMEOUT_AMOUNT, TimeUnit.MINUTES).build();
+
   private CacheService cacheService;
 
-  public CatalogueService(Vertx vertx, JsonObject config,CacheService cacheService) {
+  public CatalogueService(Vertx vertx, JsonObject config, CacheService cacheService) {
     this.vertx = vertx;
     catHost = config.getString("catServerHost");
     catPort = config.getInteger("catServerPort");
 //    catSearchPath = Constants.CAT_RSG_PATH;
-//    catItemPath = Constants.CAT_ITEM_PATH;
-    this.cacheService=cacheService;
+    catItemPath = Constants.CAT_ITEM_PATH;
+    this.cacheService = cacheService;
+    // WebClientOptions options =
+    // new WebClientOptions().setTrustAll(true).setVerifyHost(false).setSsl(true);
+    // if(catWebClient == null)
+    // {
+    // catWebClient = WebClient.create(vertx, options);
+    // }
+    // populateCache();
+    // cacheTimerid = vertx.setPeriodic(TimeUnit.DAYS.toMillis(1), handler -> {
+    // populateCache();
+    // });
   }
 
   /**
@@ -67,203 +77,201 @@ public class CatalogueService {
    * 
    * @return
    */
-//  private Future<Boolean> populateCache() {
-//    Promise<Boolean> promise = Promise.promise();
-//    catWebClient.get(catPort, catHost, catSearchPath)
-//        .addQueryParam("property", "[iudxResourceAPIs]")
-//        .addQueryParam("value", "[[TEMPORAL,ATTR,SPATIAL]]")
-//        .addQueryParam("filter", "[iudxResourceAPIs,id]").expect(ResponsePredicate.JSON)
-//        .send(handler -> {
-//          if (handler.succeeded()) {
-//            JsonArray response = handler.result().bodyAsJsonObject().getJsonArray("results");
-//            response.forEach(json -> {
-//              JsonObject res = (JsonObject) json;
-//              String id = res.getString("id");
-//              String[] idArray = id.split("/");
-//              if (idArray.length == 4) {
-//                applicableFilterCache.put(id + "/*", toList(res.getJsonArray("iudxResourceAPIs")));
-//              } else {
-//                applicableFilterCache.put(id, toList(res.getJsonArray("iudxResourceAPIs")));
-//              }
-//            });
-//            promise.complete(true);
-//          } else if (handler.failed()) {
-//            promise.fail(handler.cause());
-//          }
-//        });
-//    return promise.future();
-//  }
+  // private Future<Boolean> populateCache() {
+  // Promise<Boolean> promise = Promise.promise();
+  // catWebClient.get(catPort, catHost, catSearchPath)
+  // .addQueryParam("property", "[iudxResourceAPIs]")
+  // .addQueryParam("value", "[[TEMPORAL,ATTR,SPATIAL]]")
+  // .addQueryParam("filter", "[iudxResourceAPIs,id]").expect(ResponsePredicate.JSON)
+  // .send(handler -> {
+  // if (handler.succeeded()) {
+  // JsonArray response = handler.result().bodyAsJsonObject().getJsonArray("results");
+  // response.forEach(json -> {
+  // JsonObject res = (JsonObject) json;
+  // String id = res.getString("id");
+  // String[] idArray = id.split("/");
+  // if (idArray.length == 4) {
+  // applicableFilterCache.put(id + "/*", toList(res.getJsonArray("iudxResourceAPIs")));
+  // } else {
+  // applicableFilterCache.put(id, toList(res.getJsonArray("iudxResourceAPIs")));
+  // }
+  // });
+  // promise.complete(true);
+  // } else if (handler.failed()) {
+  // promise.fail(handler.cause());
+  // }
+  // });
+  // return promise.future();
+  // }
 
 
-//  public Future<List<String>> getApplicableFilters(String id) {
-//    Promise<List<String>> promise = Promise.promise();
-//    String groupId = id.substring(0, id.lastIndexOf("/"));
-//    List<String> filters = cache.getIfPresent(id);
-//    if (filters == null) {
-//      // check for group if not present by item key.
-//      filters = applicableFilterCache.getIfPresent(groupId + "/*");
-//    }
-//    if (filters == null) {
-//      // filters = fetchFilters4Item(id, groupId);
-//      fetchFilters4Item(id, groupId).onComplete(handler -> {
-//        if (handler.succeeded()) {
-//          promise.complete(handler.result());
-//        } else {
-//          promise.fail("failed to fetch filters.");
-//        }
-//      });
-//    } else {
-//      promise.complete(filters);
-//    }
-//    return promise.future();
-//  }
-  
+  // public Future<List<String>> getApplicableFilters(String id) {
+  // Promise<List<String>> promise = Promise.promise();
+  // String groupId = id.substring(0, id.lastIndexOf("/"));
+  // List<String> filters = cache.getIfPresent(id);
+  // if (filters == null) {
+  // // check for group if not present by item key.
+  // filters = applicableFilterCache.getIfPresent(groupId + "/*");
+  // }
+  // if (filters == null) {
+  // // filters = fetchFilters4Item(id, groupId);
+  // fetchFilters4Item(id, groupId).onComplete(handler -> {
+  // if (handler.succeeded()) {
+  // promise.complete(handler.result());
+  // } else {
+  // promise.fail("failed to fetch filters.");
+  // }
+  // });
+  // } else {
+  // promise.complete(filters);
+  // }
+  // return promise.future();
+  // }
+
   public Future<List<String>> getApplicableFilters(String id) {
     Promise<List<String>> promise = Promise.promise();
     List<String> filters = new ArrayList<String>();
     String groupId = id.substring(0, id.lastIndexOf("/"));
-    
-    JsonObject cacheRequest=new JsonObject();
+
+    JsonObject cacheRequest = new JsonObject();
     cacheRequest.put("type", CacheType.CATALOGUE_CACHE);
     cacheRequest.put("key", groupId);
-    cacheService.get(cacheRequest, cacheGroupIdResult->{
-      if(cacheGroupIdResult.succeeded() && cacheGroupIdResult.result().containsKey("iudxResourceAPIs")) {
-        JsonObject result=cacheGroupIdResult.result();
-        LOGGER.trace("result for cache groupId :{}",result);
-        filters.addAll(toList(result.getJsonArray("iudxResourceAPIs")));
-        promise.complete(filters);
-      }else {
-        cacheRequest.put("key", id);
-        cacheService.get(cacheRequest, cacheResourceIdResult->{
-          if(cacheResourceIdResult.succeeded()) {
-            JsonObject result=cacheResourceIdResult.result();
-            LOGGER.trace("result for cache resourceId :{}",result);
-            filters.addAll(toList(result.getJsonArray("iudxResourceAPIs")));
-            promise.complete(filters);
-          }else {
-            promise.fail("no filters available");
-          }
-        });
+    Future<JsonObject> groupFilter = cacheService.get(cacheRequest);
+    JsonObject itemCacheRequest = cacheRequest.copy();
+    itemCacheRequest.put("key", id);
+    Future<JsonObject> itemFilters = cacheService.get(itemCacheRequest);
+    CompositeFuture.all(List.of(groupFilter, itemFilters)).onComplete(ar -> {
+      if(ar.failed()) {
+        promise.fail("no filters available for : "+id);
+        return;
       }
+      if(groupFilter.result().containsKey("iudxResourceAPIs")) {
+        filters.addAll(toList(groupFilter.result().getJsonArray("iudxResourceAPIs")));
+        promise.complete(filters);
+      }
+      
+      if(itemFilters.result().containsKey("iudxResourceAPIs")) {
+        filters.addAll(toList(itemFilters.result().getJsonArray("iudxResourceAPIs")));
+        promise.complete(filters);
+      }
+     
     });
     return promise.future();
   }
 
 
-//  private Future<List<String>> fetchFilters4Item(String id, String groupId) {
-//    Promise<List<String>> promise = Promise.promise();
-//    Future<List<String>> getItemFilters = getFilterFromItemId(id);
-//    Future<List<String>> getGroupFilters = getFilterFromGroupId(groupId);
-//    getItemFilters.onComplete(itemHandler -> {
-//      if (itemHandler.succeeded()) {
-//        List<String> filters4Item = itemHandler.result();
-//        if (filters4Item.isEmpty()) {
-//          // Future<List<String>> getGroupFilters = getFilterFromGroupId(groupId);
-//          getGroupFilters.onComplete(groupHandler -> {
-//            if (groupHandler.succeeded()) {
-//              List<String> filters4Group = groupHandler.result();
-//              applicableFilterCache.put(groupId + "/*", filters4Group);
-//              promise.complete(filters4Group);
-//            } else {
-//              LOGGER.error(
-//                  "Failed to fetch applicable filters for id: " + id + "or group id : " + groupId);
-//            }
-//          });
-//        } else {
-//          applicableFilterCache.put(id, filters4Item);
-//          promise.complete(filters4Item);
-//        }
-//      } else {
-//
-//      }
-//    });
-//    return promise.future();
-//  }
-//
-//
-//  private Future<List<String>> getFilterFromGroupId(String groupId) {
-//    Promise<List<String>> promise = Promise.promise();
-//    callCatalogueAPI(groupId, handler -> {
-//      if (handler.succeeded()) {
-//        promise.complete(handler.result());
-//      } else {
-//        promise.fail("failed to fetch filters for group");
-//      }
-//    });
-//    return promise.future();
-//  }
-//
-//  private Future<List<String>> getFilterFromItemId(String itemId) {
-//    Promise<List<String>> promise = Promise.promise();
-//    callCatalogueAPI(itemId, handler -> {
-//      if (handler.succeeded()) {
-//        promise.complete(handler.result());
-//      } else {
-//        promise.fail("failed to fetch filters for group");
-//      }
-//    });
-//    return promise.future();
-//  }
-//
-//  private void callCatalogueAPI(String id, Handler<AsyncResult<List<String>>> handler) {
-//    List<String> filters = new ArrayList<String>();
-//    catWebClient.get(catPort, catHost, catItemPath).addQueryParam("id", id).send(catHandler -> {
-//      if (catHandler.succeeded()) {
-//        JsonArray response = catHandler.result().bodyAsJsonObject().getJsonArray("results");
-//        response.forEach(json -> {
-//          JsonObject res = (JsonObject) json;
-//          if (res.containsKey("iudxResourceAPIs")) {
-//            filters.addAll(toList(res.getJsonArray("iudxResourceAPIs")));
-//          }
-//        });
-//        handler.handle(Future.succeededFuture(filters));
-//      } else if (catHandler.failed()) {
-//        LOGGER.error("catalogue call(/iudx/cat/v1/item) failed for id" + id);
-//        handler.handle(Future.failedFuture("catalogue call(/iudx/cat/v1/item) failed for id" + id));
-//      }
-//    });
-//  }
+  // private Future<List<String>> fetchFilters4Item(String id, String groupId) {
+  // Promise<List<String>> promise = Promise.promise();
+  // Future<List<String>> getItemFilters = getFilterFromItemId(id);
+  // Future<List<String>> getGroupFilters = getFilterFromGroupId(groupId);
+  // getItemFilters.onComplete(itemHandler -> {
+  // if (itemHandler.succeeded()) {
+  // List<String> filters4Item = itemHandler.result();
+  // if (filters4Item.isEmpty()) {
+  // // Future<List<String>> getGroupFilters = getFilterFromGroupId(groupId);
+  // getGroupFilters.onComplete(groupHandler -> {
+  // if (groupHandler.succeeded()) {
+  // List<String> filters4Group = groupHandler.result();
+  // applicableFilterCache.put(groupId + "/*", filters4Group);
+  // promise.complete(filters4Group);
+  // } else {
+  // LOGGER.error(
+  // "Failed to fetch applicable filters for id: " + id + "or group id : " + groupId);
+  // }
+  // });
+  // } else {
+  // applicableFilterCache.put(id, filters4Item);
+  // promise.complete(filters4Item);
+  // }
+  // } else {
+  //
+  // }
+  // });
+  // return promise.future();
+  // }
+  //
+  //
+  // private Future<List<String>> getFilterFromGroupId(String groupId) {
+  // Promise<List<String>> promise = Promise.promise();
+  // callCatalogueAPI(groupId, handler -> {
+  // if (handler.succeeded()) {
+  // promise.complete(handler.result());
+  // } else {
+  // promise.fail("failed to fetch filters for group");
+  // }
+  // });
+  // return promise.future();
+  // }
+  //
+  // private Future<List<String>> getFilterFromItemId(String itemId) {
+  // Promise<List<String>> promise = Promise.promise();
+  // callCatalogueAPI(itemId, handler -> {
+  // if (handler.succeeded()) {
+  // promise.complete(handler.result());
+  // } else {
+  // promise.fail("failed to fetch filters for group");
+  // }
+  // });
+  // return promise.future();
+  // }
+  //
+  // private void callCatalogueAPI(String id, Handler<AsyncResult<List<String>>> handler) {
+  // List<String> filters = new ArrayList<String>();
+  // catWebClient.get(catPort, catHost, catItemPath).addQueryParam("id", id).send(catHandler -> {
+  // if (catHandler.succeeded()) {
+  // JsonArray response = catHandler.result().bodyAsJsonObject().getJsonArray("results");
+  // response.forEach(json -> {
+  // JsonObject res = (JsonObject) json;
+  // if (res.containsKey("iudxResourceAPIs")) {
+  // filters.addAll(toList(res.getJsonArray("iudxResourceAPIs")));
+  // }
+  // });
+  // handler.handle(Future.succeededFuture(filters));
+  // } else if (catHandler.failed()) {
+  // LOGGER.error("catalogue call(/iudx/cat/v1/item) failed for id" + id);
+  // handler.handle(Future.failedFuture("catalogue call(/iudx/cat/v1/item) failed for id" + id));
+  // }
+  // });
+  // }
 
-  
-  
+
+
   public Future<Boolean> isItemExist(String id) {
     LOGGER.trace("isItemExist() started");
     Promise<Boolean> promise = Promise.promise();
-    
-    JsonObject cacheRequest=new JsonObject();
+    JsonObject cacheRequest = new JsonObject();
     cacheRequest.put("type", CacheType.CATALOGUE_CACHE);
     cacheRequest.put("key", id);
-    cacheService.get(cacheRequest, cacheCallHandler->{
-      if(cacheCallHandler.succeeded()) {
-        promise.complete(true);
-      }else {
-        promise.fail("Item not found");
-      }
+    Future<JsonObject> cacheFuture = cacheService.get(cacheRequest);
+    cacheFuture.onSuccess(successHandler -> {
+      promise.complete(true);
+    }).onFailure(failureHandler -> {
+      promise.fail("Item not found");
     });
     return promise.future();
   }
-  
-//  public Future<Boolean> isItemExist(String id) {
-//    LOGGER.trace("isItemExist() started");
-//    Promise<Boolean> promise = Promise.promise();
-//    LOGGER.info("id : " + id);
-//    catWebClient.get(catPort, catHost, catItemPath).addQueryParam("id", id)
-//        .expect(ResponsePredicate.JSON).send(responseHandler -> {
-//          if (responseHandler.succeeded()) {
-//            HttpResponse<Buffer> response = responseHandler.result();
-//            JsonObject responseBody = response.bodyAsJsonObject();
-//            if (responseBody.getString("type").equalsIgnoreCase("urn:dx:cat:Success")
-//                && responseBody.getInteger("totalHits") > 0) {
-//              promise.complete(true);
-//            } else {
-//              promise.fail(responseHandler.cause());
-//            }
-//          } else {
-//            promise.fail(responseHandler.cause());
-//          }
-//        });
-//    return promise.future();
-//  }
+
+  // public Future<Boolean> isItemExist(String id) {
+  // LOGGER.trace("isItemExist() started");
+  // Promise<Boolean> promise = Promise.promise();
+  // LOGGER.info("id : " + id);
+  // catWebClient.get(catPort, catHost, catItemPath).addQueryParam("id", id)
+  // .expect(ResponsePredicate.JSON).send(responseHandler -> {
+  // if (responseHandler.succeeded()) {
+  // HttpResponse<Buffer> response = responseHandler.result();
+  // JsonObject responseBody = response.bodyAsJsonObject();
+  // if (responseBody.getString("type").equalsIgnoreCase("urn:dx:cat:Success")
+  // && responseBody.getInteger("totalHits") > 0) {
+  // promise.complete(true);
+  // } else {
+  // promise.fail(responseHandler.cause());
+  // }
+  // } else {
+  // promise.fail(responseHandler.cause());
+  // }
+  // });
+  // return promise.future();
+  // }
 
   public Future<Boolean> isItemExist(List<String> ids) {
     Promise<Boolean> promise = Promise.promise();
@@ -271,7 +279,6 @@ public class CatalogueService {
     for (String id : ids) {
       futures.add(isItemExist(id));
     }
-
     CompositeFuture.all(futures).onComplete(handler -> {
       if (handler.succeeded()) {
         promise.complete(true);

--- a/src/main/java/iudx/resource/server/apiserver/service/CatalogueService.java
+++ b/src/main/java/iudx/resource/server/apiserver/service/CatalogueService.java
@@ -27,6 +27,8 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import iudx.resource.server.authenticator.Constants;
+import iudx.resource.server.cache.CacheService;
+import iudx.resource.server.cache.cacheImpl.CacheType;
 
 /**
  * catalogue service to fetch calatogue items and groups for the purpose of cache
@@ -45,30 +47,19 @@ public class CatalogueService {
   private String catItemPath;
   private String catSearchPath;
 
-  private final Cache<String, List<String>> applicableFilterCache =
-      CacheBuilder.newBuilder().maximumSize(1000)
-          .expireAfterAccess(Constants.CACHE_TIMEOUT_AMOUNT, TimeUnit.MINUTES).build();
+//  private final Cache<String, List<String>> applicableFilterCache =
+//      CacheBuilder.newBuilder().maximumSize(1000)
+//          .expireAfterAccess(Constants.CACHE_TIMEOUT_AMOUNT, TimeUnit.MINUTES).build();
+  
+  private CacheService cacheService;
 
-  public CatalogueService(Vertx vertx, JsonObject config) {
+  public CatalogueService(Vertx vertx, JsonObject config,CacheService cacheService) {
     this.vertx = vertx;
     catHost = config.getString("catServerHost");
     catPort = config.getInteger("catServerPort");
-    catBasePath = config.getString("dxCatalogueBasePath");
-    catItemPath = catBasePath + CAT_ITEM_PATH;
-    catSearchPath = catBasePath + CAT_SEARCH_PATH;
-
-
-
-    WebClientOptions options =
-        new WebClientOptions().setTrustAll(true).setVerifyHost(false).setSsl(true);
-    if(catWebClient == null)
-    {
-      catWebClient = WebClient.create(vertx, options);
-    }
-    populateCache();
-    cacheTimerid = vertx.setPeriodic(TimeUnit.DAYS.toMillis(1), handler -> {
-      populateCache();
-    });
+//    catSearchPath = Constants.CAT_RSG_PATH;
+//    catItemPath = Constants.CAT_ITEM_PATH;
+    this.cacheService=cacheService;
   }
 
   /**
@@ -76,155 +67,203 @@ public class CatalogueService {
    * 
    * @return
    */
-  private Future<Boolean> populateCache() {
-    Promise<Boolean> promise = Promise.promise();
-    catWebClient.get(catPort, catHost, catSearchPath)
-        .addQueryParam("property", "[iudxResourceAPIs]")
-        .addQueryParam("value", "[[TEMPORAL,ATTR,SPATIAL]]")
-        .addQueryParam("filter", "[iudxResourceAPIs,id]").expect(ResponsePredicate.JSON)
-        .send(handler -> {
-          if (handler.succeeded()) {
-            JsonArray response = handler.result().bodyAsJsonObject().getJsonArray("results");
-            response.forEach(json -> {
-              JsonObject res = (JsonObject) json;
-              String id = res.getString("id");
-              String[] idArray = id.split("/");
-              if (idArray.length == 4) {
-                applicableFilterCache.put(id + "/*", toList(res.getJsonArray("iudxResourceAPIs")));
-              } else {
-                applicableFilterCache.put(id, toList(res.getJsonArray("iudxResourceAPIs")));
-              }
-            });
-            promise.complete(true);
-          } else if (handler.failed()) {
-            promise.fail(handler.cause());
-          }
-        });
-    return promise.future();
-  }
+//  private Future<Boolean> populateCache() {
+//    Promise<Boolean> promise = Promise.promise();
+//    catWebClient.get(catPort, catHost, catSearchPath)
+//        .addQueryParam("property", "[iudxResourceAPIs]")
+//        .addQueryParam("value", "[[TEMPORAL,ATTR,SPATIAL]]")
+//        .addQueryParam("filter", "[iudxResourceAPIs,id]").expect(ResponsePredicate.JSON)
+//        .send(handler -> {
+//          if (handler.succeeded()) {
+//            JsonArray response = handler.result().bodyAsJsonObject().getJsonArray("results");
+//            response.forEach(json -> {
+//              JsonObject res = (JsonObject) json;
+//              String id = res.getString("id");
+//              String[] idArray = id.split("/");
+//              if (idArray.length == 4) {
+//                applicableFilterCache.put(id + "/*", toList(res.getJsonArray("iudxResourceAPIs")));
+//              } else {
+//                applicableFilterCache.put(id, toList(res.getJsonArray("iudxResourceAPIs")));
+//              }
+//            });
+//            promise.complete(true);
+//          } else if (handler.failed()) {
+//            promise.fail(handler.cause());
+//          }
+//        });
+//    return promise.future();
+//  }
 
 
+//  public Future<List<String>> getApplicableFilters(String id) {
+//    Promise<List<String>> promise = Promise.promise();
+//    String groupId = id.substring(0, id.lastIndexOf("/"));
+//    List<String> filters = cache.getIfPresent(id);
+//    if (filters == null) {
+//      // check for group if not present by item key.
+//      filters = applicableFilterCache.getIfPresent(groupId + "/*");
+//    }
+//    if (filters == null) {
+//      // filters = fetchFilters4Item(id, groupId);
+//      fetchFilters4Item(id, groupId).onComplete(handler -> {
+//        if (handler.succeeded()) {
+//          promise.complete(handler.result());
+//        } else {
+//          promise.fail("failed to fetch filters.");
+//        }
+//      });
+//    } else {
+//      promise.complete(filters);
+//    }
+//    return promise.future();
+//  }
+  
   public Future<List<String>> getApplicableFilters(String id) {
     Promise<List<String>> promise = Promise.promise();
-    // Note: id should be a complete id not a group id (ex : domain/SHA/rs/rs-group/itemId)
-    String groupId = id.substring(0, id.lastIndexOf("/"));
-    // check for item in cache.
-    List<String> filters = applicableFilterCache.getIfPresent(id);
-    if (filters == null) {
-      // check for group if not present by item key.
-      filters = applicableFilterCache.getIfPresent(groupId + "/*");
-    }
-    if (filters == null) {
-      // filters = fetchFilters4Item(id, groupId);
-      fetchFilters4Item(id, groupId).onComplete(handler -> {
-        if (handler.succeeded()) {
-          promise.complete(handler.result());
-        } else {
-          promise.fail("failed to fetch filters.");
-        }
-      });
-    } else {
-      promise.complete(filters);
-    }
-    return promise.future();
-  }
-
-
-  private Future<List<String>> fetchFilters4Item(String id, String groupId) {
-    Promise<List<String>> promise = Promise.promise();
-    Future<List<String>> getItemFilters = getFilterFromItemId(id);
-    Future<List<String>> getGroupFilters = getFilterFromGroupId(groupId);
-    getItemFilters.onComplete(itemHandler -> {
-      if (itemHandler.succeeded()) {
-        List<String> filters4Item = itemHandler.result();
-        if (filters4Item.isEmpty()) {
-          // Future<List<String>> getGroupFilters = getFilterFromGroupId(groupId);
-          getGroupFilters.onComplete(groupHandler -> {
-            if (groupHandler.succeeded()) {
-              List<String> filters4Group = groupHandler.result();
-              applicableFilterCache.put(groupId + "/*", filters4Group);
-              promise.complete(filters4Group);
-            } else {
-              LOGGER.error(
-                  "Failed to fetch applicable filters for id: " + id + "or group id : " + groupId);
-            }
-          });
-        } else {
-          applicableFilterCache.put(id, filters4Item);
-          promise.complete(filters4Item);
-        }
-      } else {
-
-      }
-    });
-    return promise.future();
-  }
-
-
-  private Future<List<String>> getFilterFromGroupId(String groupId) {
-    Promise<List<String>> promise = Promise.promise();
-    callCatalogueAPI(groupId, handler -> {
-      if (handler.succeeded()) {
-        promise.complete(handler.result());
-      } else {
-        promise.fail("failed to fetch filters for group");
-      }
-    });
-    return promise.future();
-  }
-
-  private Future<List<String>> getFilterFromItemId(String itemId) {
-    Promise<List<String>> promise = Promise.promise();
-    callCatalogueAPI(itemId, handler -> {
-      if (handler.succeeded()) {
-        promise.complete(handler.result());
-      } else {
-        promise.fail("failed to fetch filters for group");
-      }
-    });
-    return promise.future();
-  }
-
-  private void callCatalogueAPI(String id, Handler<AsyncResult<List<String>>> handler) {
     List<String> filters = new ArrayList<String>();
-    catWebClient.get(catPort, catHost, catItemPath).addQueryParam("id", id).send(catHandler -> {
-      if (catHandler.succeeded()) {
-        JsonArray response = catHandler.result().bodyAsJsonObject().getJsonArray("results");
-        response.forEach(json -> {
-          JsonObject res = (JsonObject) json;
-          if (res.containsKey("iudxResourceAPIs")) {
-            filters.addAll(toList(res.getJsonArray("iudxResourceAPIs")));
+    String groupId = id.substring(0, id.lastIndexOf("/"));
+    
+    JsonObject cacheRequest=new JsonObject();
+    cacheRequest.put("type", CacheType.CATALOGUE_CACHE);
+    cacheRequest.put("key", groupId);
+    cacheService.get(cacheRequest, cacheGroupIdResult->{
+      if(cacheGroupIdResult.succeeded() && cacheGroupIdResult.result().containsKey("iudxResourceAPIs")) {
+        JsonObject result=cacheGroupIdResult.result();
+        LOGGER.trace("result for cache groupId :{}",result);
+        filters.addAll(toList(result.getJsonArray("iudxResourceAPIs")));
+        promise.complete(filters);
+      }else {
+        cacheRequest.put("key", id);
+        cacheService.get(cacheRequest, cacheResourceIdResult->{
+          if(cacheResourceIdResult.succeeded()) {
+            JsonObject result=cacheResourceIdResult.result();
+            LOGGER.trace("result for cache resourceId :{}",result);
+            filters.addAll(toList(result.getJsonArray("iudxResourceAPIs")));
+            promise.complete(filters);
+          }else {
+            promise.fail("no filters available");
           }
         });
-        handler.handle(Future.succeededFuture(filters));
-      } else if (catHandler.failed()) {
-        LOGGER.error("catalogue call ("+ catItemPath + ") failed for id" + id);
-        handler.handle(Future.failedFuture("catalogue call(" + catItemPath + ") failed for id" + id));
       }
     });
+    return promise.future();
   }
 
+
+//  private Future<List<String>> fetchFilters4Item(String id, String groupId) {
+//    Promise<List<String>> promise = Promise.promise();
+//    Future<List<String>> getItemFilters = getFilterFromItemId(id);
+//    Future<List<String>> getGroupFilters = getFilterFromGroupId(groupId);
+//    getItemFilters.onComplete(itemHandler -> {
+//      if (itemHandler.succeeded()) {
+//        List<String> filters4Item = itemHandler.result();
+//        if (filters4Item.isEmpty()) {
+//          // Future<List<String>> getGroupFilters = getFilterFromGroupId(groupId);
+//          getGroupFilters.onComplete(groupHandler -> {
+//            if (groupHandler.succeeded()) {
+//              List<String> filters4Group = groupHandler.result();
+//              applicableFilterCache.put(groupId + "/*", filters4Group);
+//              promise.complete(filters4Group);
+//            } else {
+//              LOGGER.error(
+//                  "Failed to fetch applicable filters for id: " + id + "or group id : " + groupId);
+//            }
+//          });
+//        } else {
+//          applicableFilterCache.put(id, filters4Item);
+//          promise.complete(filters4Item);
+//        }
+//      } else {
+//
+//      }
+//    });
+//    return promise.future();
+//  }
+//
+//
+//  private Future<List<String>> getFilterFromGroupId(String groupId) {
+//    Promise<List<String>> promise = Promise.promise();
+//    callCatalogueAPI(groupId, handler -> {
+//      if (handler.succeeded()) {
+//        promise.complete(handler.result());
+//      } else {
+//        promise.fail("failed to fetch filters for group");
+//      }
+//    });
+//    return promise.future();
+//  }
+//
+//  private Future<List<String>> getFilterFromItemId(String itemId) {
+//    Promise<List<String>> promise = Promise.promise();
+//    callCatalogueAPI(itemId, handler -> {
+//      if (handler.succeeded()) {
+//        promise.complete(handler.result());
+//      } else {
+//        promise.fail("failed to fetch filters for group");
+//      }
+//    });
+//    return promise.future();
+//  }
+//
+//  private void callCatalogueAPI(String id, Handler<AsyncResult<List<String>>> handler) {
+//    List<String> filters = new ArrayList<String>();
+//    catWebClient.get(catPort, catHost, catItemPath).addQueryParam("id", id).send(catHandler -> {
+//      if (catHandler.succeeded()) {
+//        JsonArray response = catHandler.result().bodyAsJsonObject().getJsonArray("results");
+//        response.forEach(json -> {
+//          JsonObject res = (JsonObject) json;
+//          if (res.containsKey("iudxResourceAPIs")) {
+//            filters.addAll(toList(res.getJsonArray("iudxResourceAPIs")));
+//          }
+//        });
+//        handler.handle(Future.succeededFuture(filters));
+//      } else if (catHandler.failed()) {
+//        LOGGER.error("catalogue call(/iudx/cat/v1/item) failed for id" + id);
+//        handler.handle(Future.failedFuture("catalogue call(/iudx/cat/v1/item) failed for id" + id));
+//      }
+//    });
+//  }
+
+  
+  
   public Future<Boolean> isItemExist(String id) {
     LOGGER.trace("isItemExist() started");
     Promise<Boolean> promise = Promise.promise();
-    LOGGER.info("id : " + id);
-    catWebClient.get(catPort, catHost, catItemPath).addQueryParam("id", id)
-        .expect(ResponsePredicate.JSON).send(responseHandler -> {
-          if (responseHandler.succeeded()) {
-            HttpResponse<Buffer> response = responseHandler.result();
-            JsonObject responseBody = response.bodyAsJsonObject();
-            if (responseBody.getString("type").equalsIgnoreCase("urn:dx:cat:Success")
-                && responseBody.getInteger("totalHits") > 0) {
-              promise.complete(true);
-            } else {
-              promise.fail(responseHandler.cause());
-            }
-          } else {
-            promise.fail(responseHandler.cause());
-          }
-        });
+    
+    JsonObject cacheRequest=new JsonObject();
+    cacheRequest.put("type", CacheType.CATALOGUE_CACHE);
+    cacheRequest.put("key", id);
+    cacheService.get(cacheRequest, cacheCallHandler->{
+      if(cacheCallHandler.succeeded()) {
+        promise.complete(true);
+      }else {
+        promise.fail("Item not found");
+      }
+    });
     return promise.future();
   }
+  
+//  public Future<Boolean> isItemExist(String id) {
+//    LOGGER.trace("isItemExist() started");
+//    Promise<Boolean> promise = Promise.promise();
+//    LOGGER.info("id : " + id);
+//    catWebClient.get(catPort, catHost, catItemPath).addQueryParam("id", id)
+//        .expect(ResponsePredicate.JSON).send(responseHandler -> {
+//          if (responseHandler.succeeded()) {
+//            HttpResponse<Buffer> response = responseHandler.result();
+//            JsonObject responseBody = response.bodyAsJsonObject();
+//            if (responseBody.getString("type").equalsIgnoreCase("urn:dx:cat:Success")
+//                && responseBody.getInteger("totalHits") > 0) {
+//              promise.complete(true);
+//            } else {
+//              promise.fail(responseHandler.cause());
+//            }
+//          } else {
+//            promise.fail(responseHandler.cause());
+//          }
+//        });
+//    return promise.future();
+//  }
 
   public Future<Boolean> isItemExist(List<String> ids) {
     Promise<Boolean> promise = Promise.promise();

--- a/src/main/java/iudx/resource/server/authenticator/JwtAuthenticationServiceImpl.java
+++ b/src/main/java/iudx/resource/server/authenticator/JwtAuthenticationServiceImpl.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import iudx.resource.server.common.Api;
@@ -14,6 +15,7 @@ import org.apache.logging.log4j.Logger;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
@@ -54,21 +56,6 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
   final boolean isLimitsEnabled;
   final Api apis;
   final String catBasePath;
-
-  // resourceGroupCache will contains ACL info about all resource group in a resource server
-  Cache<String, String> resourceGroupCache =
-      CacheBuilder.newBuilder()
-          .maximumSize(1000)
-          .expireAfterAccess(Constants.CACHE_TIMEOUT_AMOUNT, TimeUnit.MINUTES)
-          .build();
-  // resourceIdCache will contains info about resources available(& their ACL) in resource server.
-  Cache<String, String> resourceIdCache =
-      CacheBuilder.newBuilder()
-          .maximumSize(1000)
-          .expireAfterAccess(Constants.CACHE_TIMEOUT_AMOUNT, TimeUnit.MINUTES)
-          .build();
-
-
 
   JwtAuthenticationServiceImpl(
       Vertx vertx, final JWTAuth jwtAuth, final WebClient webClient, final JsonObject config,
@@ -206,47 +193,37 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
 
     return promise.future();
   }
-
-  public Future<String> isOpenResource(String id) {
+  
+  
+  public Future<String> isOpenResource(String id){
     LOGGER.trace("isOpenResource() started");
-
     Promise<String> promise = Promise.promise();
-
-    String ACL = resourceIdCache.getIfPresent(id);
-
-    if (ACL != null) {
-      LOGGER.debug("Cache Hit");
-      promise.complete(ACL);
-    } else {
-      // cache miss
-      LOGGER.debug("Cache miss calling cat server");
-      String[] idComponents = id.split("/");
-      if (idComponents.length < 4) {
-        promise.fail("Not Found " + id);
+    
+    JsonObject cacheRequest=new JsonObject();
+    cacheRequest.put("type", CacheType.CATALOGUE_CACHE);
+    cacheRequest.put("key", id);
+    Future<JsonObject> resourceIdFuture=cache.get(cacheRequest);
+    
+    String[] idComponents = id.split("/");
+    String groupId =(idComponents.length == 4)? id:String.join("/", Arrays.copyOfRange(idComponents, 0, 4));
+    JsonObject resourceGroupCacheRequest=cacheRequest.copy();
+    resourceGroupCacheRequest.put("key", groupId);
+    Future<JsonObject> groupIdFuture=cache.get(resourceGroupCacheRequest);
+    
+    CompositeFuture.any(List.of(resourceIdFuture,groupIdFuture)).onSuccess(ar->{
+      String acl="SECURE";
+      if(groupIdFuture.result()!=null && groupIdFuture.result().containsKey("accessPolicy")) {
+        acl=groupIdFuture.result().getString("accessPolicy");
       }
-      String groupId =
-          (idComponents.length == 4)
-              ? id
-              : String.join("/", Arrays.copyOfRange(idComponents, 0, 4));
-      // 1. check group accessPolicy.
-      // 2. check resource exist, if exist set accessPolicy to group accessPolicy. else fail
-      Future<String> groupACLFuture = getGroupAccessPolicy(groupId);
-      groupACLFuture
-          .compose(
-              groupACLResult -> {
-                String groupPolicy = groupACLResult;
-                return isResourceExist(id, groupPolicy);
-              })
-          .onSuccess(
-              handler -> {
-                promise.complete(resourceIdCache.getIfPresent(id));
-              })
-          .onFailure(
-              handler -> {
-                LOGGER.error("cat response failed for Id : (" + id + ")" + handler.getCause());
-                promise.fail("Not Found " + id);
-              });
-    }
+      
+      if(resourceIdFuture.result()!=null && resourceIdFuture.result().containsKey("accessPolicy")) {
+        acl=resourceIdFuture.result().getString("accessPolicy");
+      }
+      promise.complete(acl);
+    }).onFailure(failureHandler->{
+        promise.fail("Not Found  : "+id);
+        return;
+    });
     return promise.future();
   }
 
@@ -357,16 +334,6 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
     return false;
   }
 
-  private boolean checkClosedEndPoints(String endPoint) {
-    for(String item : CLOSED_ENDPOINTS)
-    {
-      if(endPoint.contains(item))
-      {
-        return true;
-      }
-    }
-    return false;
-  }
   private JsonObject createValidateAccessSuccessResponse(JwtData jwtData) {
     String jwtId = jwtData.getIid().split(":")[1];
     JsonObject jsonResponse = new JsonObject();
@@ -413,151 +380,30 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
     String subId = jwtData.getSub();
     JsonObject requestJson = new JsonObject().put("type", cacheType).put("key", subId);
 
-    cache.get(requestJson, handler -> {
-      if (handler.succeeded()) {
-        JsonObject responseJson = handler.result();
-        LOGGER.debug("responseJson : " + responseJson);
-        String timestamp = responseJson.getString("value");
+    Future<JsonObject> cacheCallFuture=cache.get(requestJson);
+    cacheCallFuture.onSuccess(successhandler->{
+      JsonObject responseJson = successhandler;
+      LOGGER.debug("responseJson : " + responseJson);
+      String timestamp = responseJson.getString("value");
 
-        LocalDateTime revokedAt = LocalDateTime.parse(timestamp);
-        LocalDateTime jwtIssuedAt = (LocalDateTime.ofInstant(
-            Instant.ofEpochSecond(jwtData.getIat()),
-            ZoneId.systemDefault()));
+      LocalDateTime revokedAt = LocalDateTime.parse(timestamp);
+      LocalDateTime jwtIssuedAt = (LocalDateTime.ofInstant(
+          Instant.ofEpochSecond(jwtData.getIat()),
+          ZoneId.systemDefault()));
 
-        if (jwtIssuedAt.isBefore(revokedAt)) {
-          LOGGER.info("jwt issued at : " + jwtIssuedAt + " revokedAt : " + revokedAt);
-          LOGGER.error("Privilages for client are revoked.");
-          JsonObject result = new JsonObject().put("401", "revoked token passes");
-          promise.fail(result.toString());
-        } else {
-          promise.complete(true);
-        }
+      if (jwtIssuedAt.isBefore(revokedAt)) {
+        LOGGER.info("jwt issued at : " + jwtIssuedAt + " revokedAt : " + revokedAt);
+        LOGGER.error("Privilages for client are revoked.");
+        JsonObject result = new JsonObject().put("401", "revoked token passes");
+        promise.fail(result.toString());
       } else {
-        // since no value in cache, this means client_id is valid and not revoked
-        LOGGER.info("cache call result : [fail] " + handler.cause());
         promise.complete(true);
       }
-    });
-    return promise.future();
-  }
-
-  public Future<Boolean> isItemExist(String itemId) {
-    LOGGER.trace("isItemExist() started");
-    Promise<Boolean> promise = Promise.promise();
-    String id = itemId.replace("/*", "");
-    LOGGER.debug("id : " + id);
-    String catItemPath = catBasePath + CAT_ITEM_PATH;
-    catWebClient
-        .get(port, host, catItemPath)
-        .addQueryParam("id", id)
-        .expect(ResponsePredicate.JSON)
-        .send(
-            responseHandler -> {
-              if (responseHandler.succeeded()) {
-                HttpResponse<Buffer> response = responseHandler.result();
-                JsonObject responseBody = response.bodyAsJsonObject();
-                if (responseBody.getString("status").equalsIgnoreCase("success")
-                    && responseBody.getInteger("totalHits") > 0) {
-                  promise.complete(true);
-                } else {
-                  promise.fail(responseHandler.cause());
-                }
-              } else {
-                promise.fail(responseHandler.cause());
-              }
-            });
-    return promise.future();
-  }
-
-  public Future<Boolean> isResourceExist(String id, String groupACL) {
-    LOGGER.trace("isResourceExist() started");
-    Promise<Boolean> promise = Promise.promise();
-    String resourceExist = resourceIdCache.getIfPresent(id);
-    if (resourceExist != null) {
-      LOGGER.info("Info : cache Hit");
+    }).onFailure(failureHandler->{
+      LOGGER.info("cache call result : [fail] " + failureHandler);
       promise.complete(true);
-    } else {
-      LOGGER.info("Info : Cache miss : call cat server");
-      catWebClient
-          .get(port, host, path)
-          .addQueryParam("property", "[id]")
-          .addQueryParam("value", "[[" + id + "]]")
-          .addQueryParam("filter", "[id]")
-          .expect(ResponsePredicate.JSON)
-          .send(
-              responseHandler -> {
-                if (responseHandler.failed()) {
-                  promise.fail("false");
-                }
-                HttpResponse<Buffer> response = responseHandler.result();
-                JsonObject responseBody = response.bodyAsJsonObject();
-                if (response.statusCode() != HttpStatus.SC_OK) {
-                  promise.fail("false");
-                } else if (!responseBody.getString("type").equals("urn:dx:cat:Success")) {
-                  promise.fail("Not Found");
-                  return;
-                } else if (responseBody.getInteger("totalHits") == 0) {
-                  LOGGER.error("Info: Resource ID invalid : Catalogue item Not Found");
-                  promise.fail("Not Found");
-                } else {
-                  LOGGER.debug("is Exist response : " + responseBody);
-                  resourceIdCache.put(id, groupACL);
-                  promise.complete(true);
-                }
-              });
-    }
-    return promise.future();
-  }
-
-  public Future<String> getGroupAccessPolicy(String groupId) {
-    LOGGER.trace("getGroupAccessPolicy() started");
-    Promise<String> promise = Promise.promise();
-    String groupACL = resourceGroupCache.getIfPresent(groupId);
-    if (groupACL != null) {
-      LOGGER.info("Info : cache Hit");
-      promise.complete(groupACL);
-    } else {
-      LOGGER.info("Info : cache miss");
-      catWebClient
-          .get(port, host, path)
-          .addQueryParam("property", "[id]")
-          .addQueryParam("value", "[[" + groupId + "]]")
-          .addQueryParam("filter", "[accessPolicy]")
-          .expect(ResponsePredicate.JSON)
-          .send(
-              httpResponseAsyncResult -> {
-                if (httpResponseAsyncResult.failed()) {
-                  LOGGER.error(httpResponseAsyncResult.cause());
-                  promise.fail("Resource not found");
-                  return;
-                }
-                HttpResponse<Buffer> response = httpResponseAsyncResult.result();
-                if (response.statusCode() != HttpStatus.SC_OK) {
-                  promise.fail("Resource not found");
-                  return;
-                }
-                JsonObject responseBody = response.bodyAsJsonObject();
-                if (!responseBody.getString("type").equals("urn:dx:cat:Success")) {
-                  promise.fail("Resource not found");
-                  return;
-                }
-                String resourceACL = "SECURE";
-                try {
-                  resourceACL =
-                      responseBody
-                          .getJsonArray("results")
-                          .getJsonObject(0)
-                          .getString("accessPolicy");
-                  resourceGroupCache.put(groupId, resourceACL);
-                  LOGGER.debug("Info: Group ID valid : Catalogue item Found");
-                  promise.complete(resourceACL);
-                } catch (Exception ignored) {
-                  LOGGER.error("Info: Group ID invalid : Empty response in results from Catalogue",
-                      ignored);
-                  promise.fail("Resource not found");
-                }
-              });
-    }
+    });
+    
     return promise.future();
   }
 

--- a/src/main/java/iudx/resource/server/cache/CacheService.java
+++ b/src/main/java/iudx/resource/server/cache/CacheService.java
@@ -5,6 +5,7 @@ import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -42,8 +43,7 @@ public interface CacheService {
    * @param handler handler
    * @return
    */
-  @Fluent
-  CacheService get(JsonObject request, Handler<AsyncResult<JsonObject>> handler);
+  Future<JsonObject> get(JsonObject request);
 
   /**
    * put value in cache passing a json object specifying cache name (in case of multiple caches are
@@ -76,8 +76,7 @@ public interface CacheService {
    * }
    *         </pre>
    */
-  @Fluent
-  CacheService put(JsonObject request, Handler<AsyncResult<JsonObject>> handler);
+  Future<JsonObject> put(JsonObject request);
 
   /**
    * method used to refresh content of cache specifying the name of cache, key(optional) and
@@ -98,7 +97,6 @@ public interface CacheService {
    * @param handler
    * @return
    */
-  @Fluent
-  CacheService refresh(JsonObject request, Handler<AsyncResult<JsonObject>> handler);
+  Future<JsonObject> refresh(JsonObject request);
 
 }

--- a/src/main/java/iudx/resource/server/cache/CacheVerticle.java
+++ b/src/main/java/iudx/resource/server/cache/CacheVerticle.java
@@ -8,6 +8,7 @@ import io.vertx.core.AbstractVerticle;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.serviceproxy.ServiceBinder;
+import iudx.resource.server.cache.cacheImpl.CatalogueCacheImpl;
 import iudx.resource.server.database.postgres.PostgresService;
 
 public class CacheVerticle extends AbstractVerticle {
@@ -20,13 +21,14 @@ public class CacheVerticle extends AbstractVerticle {
 
   private CacheService cacheService;
   private PostgresService pgService;
+  private CatalogueCacheImpl catalogueCache;
 
   @Override
   public void start() throws Exception {
 
     pgService = PostgresService.createProxy(vertx, PG_SERVICE_ADDRESS);
-
-    cacheService = new CacheServiceImpl(vertx, pgService, config());
+    catalogueCache=new CatalogueCacheImpl(vertx, config());
+    cacheService = new CacheServiceImpl(vertx, pgService, catalogueCache);
 
     binder = new ServiceBinder(vertx);
     consumer = binder.setAddress(CACHE_SERVICE_ADDRESS).register(CacheService.class, cacheService);

--- a/src/main/java/iudx/resource/server/cache/CacheVerticle.java
+++ b/src/main/java/iudx/resource/server/cache/CacheVerticle.java
@@ -14,7 +14,6 @@ public class CacheVerticle extends AbstractVerticle {
 
   private static final Logger LOGGER = LogManager.getLogger(CacheVerticle.class);
 
-  private static final String SERVICE_ADDRESS = CACHE_SERVICE_ADDRESS;
 
   private MessageConsumer<JsonObject> consumer;
   private ServiceBinder binder;
@@ -27,16 +26,16 @@ public class CacheVerticle extends AbstractVerticle {
 
     pgService = PostgresService.createProxy(vertx, PG_SERVICE_ADDRESS);
 
-    cacheService = new CacheServiceImpl(vertx, pgService);
+    cacheService = new CacheServiceImpl(vertx, pgService, config());
 
     binder = new ServiceBinder(vertx);
-    consumer = binder.setAddress(SERVICE_ADDRESS).register(CacheService.class, cacheService);
+    consumer = binder.setAddress(CACHE_SERVICE_ADDRESS).register(CacheService.class, cacheService);
 
     LOGGER.info("Cache Verticle deployed.");
   }
 
   @Override
   public void stop() {
-        binder.unregister(consumer);
+    binder.unregister(consumer);
   }
 }

--- a/src/main/java/iudx/resource/server/cache/cacheImpl/CacheType.java
+++ b/src/main/java/iudx/resource/server/cache/cacheImpl/CacheType.java
@@ -2,7 +2,8 @@ package iudx.resource.server.cache.cacheImpl;
 
 public enum CacheType {
   REVOKED_CLIENT("revoked_client"),
-  UNIQUE_ATTRIBUTE("unique_attribute");
+  UNIQUE_ATTRIBUTE("unique_attribute"),
+  CATALOGUE_CACHE("catalogue_cache");
 
   String cacheName;
 

--- a/src/main/java/iudx/resource/server/cache/cacheImpl/CacheValue.java
+++ b/src/main/java/iudx/resource/server/cache/cacheImpl/CacheValue.java
@@ -1,0 +1,5 @@
+package iudx.resource.server.cache.cacheImpl;
+
+public interface CacheValue<V> {
+  V getValue();
+}

--- a/src/main/java/iudx/resource/server/cache/cacheImpl/CatalogueCacheImpl.java
+++ b/src/main/java/iudx/resource/server/cache/cacheImpl/CatalogueCacheImpl.java
@@ -61,7 +61,11 @@ public class CatalogueCacheImpl implements IudxCache {
     } else {
       populateCache()
       .onSuccess(successHandler -> {
-        promise.complete(cache.getIfPresent(key));
+        if(cache.getIfPresent(key)!=null) {
+          promise.complete(cache.getIfPresent(key));
+        }else {
+          promise.fail("key not found");
+        }
       }).onFailure(failureHandler -> {
         promise.fail("Value not found");
       });

--- a/src/main/java/iudx/resource/server/cache/cacheImpl/CatalogueCacheImpl.java
+++ b/src/main/java/iudx/resource/server/cache/cacheImpl/CatalogueCacheImpl.java
@@ -1,0 +1,119 @@
+package iudx.resource.server.cache.cacheImpl;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
+
+public class CatalogueCacheImpl implements IudxCache {
+
+  private static final Logger LOGGER = LogManager.getLogger(CatalogueCacheImpl.class);
+  private final static CacheType cacheType = CacheType.CATALOGUE_CACHE;
+
+  private WebClient catWebClient;
+  private String catHost;
+  private int catPort;;
+
+  private final Cache<String, CacheValue<JsonObject>> cache =
+      CacheBuilder.newBuilder().maximumSize(5000).expireAfterWrite(1L, TimeUnit.DAYS).build();
+  private Vertx vertx;
+
+  public CatalogueCacheImpl(Vertx vertx, JsonObject config) {
+    this.vertx = vertx;
+    LOGGER.debug("config : {}",config);
+    this.catHost=config.getString("catServerHost");
+    this.catPort=config.getInteger("catServerPort");
+    
+    
+    WebClientOptions options =
+        new WebClientOptions().setTrustAll(true).setVerifyHost(false).setSsl(true);
+    if(catWebClient == null)
+    {
+      catWebClient = WebClient.create(vertx, options);
+    }
+    
+    refreshCache();
+    vertx.setPeriodic(TimeUnit.HOURS.toMillis(1), handler -> {
+      refreshCache();
+    });
+  }
+
+  @Override
+  public Future<Void> put(String key, CacheValue<JsonObject> value) {
+    throw new RuntimeException("Adding elements in cache are not allowed, only refresh can be used");
+  }
+
+  @Override
+  public Future<CacheValue<JsonObject>> get(String key) {
+    LOGGER.trace("request for id : {}",key);
+    Promise<CacheValue<JsonObject>> promise=Promise.promise();
+    if (cache.getIfPresent(key) != null) {
+      return Future.succeededFuture(cache.getIfPresent(key));
+    } else {
+      populateCache()
+      .onSuccess(successHandler -> {
+        promise.complete(cache.getIfPresent(key));
+      }).onFailure(failureHandler -> {
+        promise.fail("Value not found");
+      });
+    }
+    return promise.future();
+  }
+
+  @Override
+  public Future<Void> refreshCache() {
+    populateCache();
+    LOGGER.trace(cacheType + " refreshCache() called");
+    return Future.succeededFuture();
+  }
+
+  private Future<Void> populateCache() {
+    Promise<Void> promise = Promise.promise();
+    catWebClient
+        .get(catPort, catHost, "/iudx/cat/v1/search")
+          .addQueryParam("property", "[itemStatus]")
+          .addQueryParam("value", "[[ACTIVE]]")
+          .addQueryParam("filter", "[id,provider,name,description,authControlGroup,accessPolicy,iudxResourceAPIs]")
+          .expect(ResponsePredicate.JSON)
+          .send(catHandler -> {
+            if (catHandler.succeeded()) {
+              JsonArray response = catHandler.result().bodyAsJsonObject().getJsonArray("results");
+              //LOGGER.debug("results : {}",catHandler.result().bodyAsJsonObject());
+              cache.invalidateAll();
+              response.forEach(json -> {
+                JsonObject res = (JsonObject) json;
+                String id=res.getString("id");
+                CacheValue<JsonObject> cacheValue=createCacheValue(id, res.toString());
+                cache.put(id, cacheValue);
+              });
+             // LOGGER.debug("cache value :{}",cache.getIfPresent("datakaveri.org/b8bd3e3f39615c8ec96722131ae95056b5938f2f/rs.iudx.io/varanasi-swm-vehicle-live").getValue());
+              promise.complete();
+            } else if (catHandler.failed()) {
+              LOGGER.error("Failed to populate catalogue cache");
+              promise.fail("Failed to populate catalogue cache");
+            }
+          });
+    
+    return promise.future();
+  }
+
+  @Override
+  public CacheValue<JsonObject> createCacheValue(String key, String value){
+    return new CacheValue<JsonObject>() {
+      @Override
+      public JsonObject getValue() {
+        return new JsonObject(value);
+      }
+    };
+  }
+
+}

--- a/src/main/java/iudx/resource/server/cache/cacheImpl/CatalogueItems.java
+++ b/src/main/java/iudx/resource/server/cache/cacheImpl/CatalogueItems.java
@@ -1,0 +1,15 @@
+package iudx.resource.server.cache.cacheImpl;
+
+import java.util.List;
+
+public class CatalogueItems {
+  
+  private String id;
+  private String name;
+  private String description;
+  private String provider;
+  private String accessPolicy;
+  private List<String> iudxResourceAPIs;
+  
+
+}

--- a/src/main/java/iudx/resource/server/cache/cacheImpl/IudxCache.java
+++ b/src/main/java/iudx/resource/server/cache/cacheImpl/IudxCache.java
@@ -1,10 +1,15 @@
 package iudx.resource.server.cache.cacheImpl;
 
-public interface IudxCache {
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
 
-  public void put(String key, String value);
+public interface IudxCache{
 
-  public String get(String key);
+  public Future<Void> put(String key, CacheValue<JsonObject> value);
 
-  public void refreshCache();
+  public Future<CacheValue<JsonObject>> get(String key);
+
+  public Future<Void> refreshCache();
+  
+  public CacheValue<JsonObject> createCacheValue(String key, String value);
 }

--- a/src/main/java/iudx/resource/server/cache/cacheImpl/RevokedClientCache.java
+++ b/src/main/java/iudx/resource/server/cache/cacheImpl/RevokedClientCache.java
@@ -5,6 +5,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -16,11 +18,8 @@ public class RevokedClientCache implements IudxCache {
   private static final Logger LOGGER = LogManager.getLogger(RevokedClientCache.class);
   private final static CacheType cacheType = CacheType.REVOKED_CLIENT;
 
-  private final Cache<String, String> cache =
-      CacheBuilder.newBuilder()
-          .maximumSize(5000)
-          .expireAfterWrite(1L, TimeUnit.DAYS)
-          .build();
+  private final Cache<String, CacheValue<JsonObject>> cache =
+      CacheBuilder.newBuilder().maximumSize(5000).expireAfterWrite(1L, TimeUnit.DAYS).build();
 
   private PostgresService pgService;
 
@@ -34,18 +33,25 @@ public class RevokedClientCache implements IudxCache {
   }
 
   @Override
-  public void put(String key, String value) {
+  public Future<Void> put(String key, CacheValue<JsonObject> value) {
     cache.put(key, value);
+    return Future.succeededFuture();
+
   }
 
   @Override
-  public String get(String key) {
-    return cache.getIfPresent(key);
+  public Future<CacheValue<JsonObject>> get(String key) {
+    if(cache.getIfPresent(key)!=null) {
+      return Future.succeededFuture(cache.getIfPresent(key));
+    }else {
+      return Future.failedFuture("Value not found");
+    }
   }
 
   @Override
-  public void refreshCache() {
+  public Future<Void> refreshCache() {
     LOGGER.trace(cacheType + " refreshCache() called");
+    Promise<Void> promise=Promise.promise();
     String query = Constants.SELECT_REVOKE_TOKEN_SQL;
     pgService.executeQuery(query, handler -> {
       if (handler.succeeded()) {
@@ -54,14 +60,30 @@ public class RevokedClientCache implements IudxCache {
         clientIdArray.forEach(e -> {
           JsonObject clientInfo = (JsonObject) e;
           String key = clientInfo.getString("_id");
-          String value = clientInfo.getString("expiry");
-          this.cache.put(key, value);
+          String expiry =clientInfo.getString("expiry");
+          CacheValue<JsonObject> cacheValue=createCacheValue(key, expiry);
+          this.cache.put(key, cacheValue);
         });
-
+        promise.complete();
+      }else {
+        promise.fail("failed to refresh");
       }
     });
+    return promise.future();
   }
-
-
+  
+  @Override
+  public CacheValue<JsonObject> createCacheValue(String key, String expiry){
+    return new CacheValue<JsonObject>() {
+      @Override
+      public JsonObject getValue() {
+        JsonObject value=new JsonObject();
+        value.put("id", key);
+        value.put("expiry", expiry);
+        return value;
+      }
+      
+    };
+  }
 
 }

--- a/src/main/java/iudx/resource/server/cache/cacheImpl/RevokedClientCache.java
+++ b/src/main/java/iudx/resource/server/cache/cacheImpl/RevokedClientCache.java
@@ -80,6 +80,7 @@ public class RevokedClientCache implements IudxCache {
         JsonObject value=new JsonObject();
         value.put("id", key);
         value.put("expiry", expiry);
+        value.put("value", expiry);
         return value;
       }
       

--- a/src/main/java/iudx/resource/server/cache/cacheImpl/UniqueAttributeCache.java
+++ b/src/main/java/iudx/resource/server/cache/cacheImpl/UniqueAttributeCache.java
@@ -78,7 +78,9 @@ public class UniqueAttributeCache implements IudxCache {
       public JsonObject getValue() {
         JsonObject value=new JsonObject();
         value.put("resource_id", id);
+        value.put("key", id);
         value.put("unique_attribute", unique_attrib);
+        value.put("value", unique_attrib);
         return value;
       }
       

--- a/src/main/java/iudx/resource/server/cache/cacheImpl/UniqueAttributeCache.java
+++ b/src/main/java/iudx/resource/server/cache/cacheImpl/UniqueAttributeCache.java
@@ -5,6 +5,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -18,11 +20,8 @@ public class UniqueAttributeCache implements IudxCache {
 
   private final PostgresService postgresService;
 
-  private final Cache<String, String> cache =
-      CacheBuilder.newBuilder()
-          .maximumSize(5000)
-          .expireAfterWrite(1L, TimeUnit.DAYS)
-          .build();
+  private final Cache<String, CacheValue<JsonObject>> cache =
+      CacheBuilder.newBuilder().maximumSize(5000).expireAfterWrite(1L, TimeUnit.DAYS).build();
 
   public UniqueAttributeCache(Vertx vertx, PostgresService postgresService) {
     this.postgresService = postgresService;
@@ -34,17 +33,23 @@ public class UniqueAttributeCache implements IudxCache {
   }
 
   @Override
-  public void put(String key, String value) {
+  public Future<Void> put(String key, CacheValue<JsonObject> value) {
     cache.put(key, value);
+    return Future.succeededFuture();
   }
 
   @Override
-  public String get(String key) {
-    return cache.getIfPresent(key);
+  public Future<CacheValue<JsonObject>> get(String key) {
+    if (cache.getIfPresent(key) != null) {
+      return Future.succeededFuture(cache.getIfPresent(key));
+    } else {
+      return Future.failedFuture("Value not found");
+    }
   }
 
   @Override
-  public void refreshCache() {
+  public Future<Void> refreshCache() {
+    Promise<Void> promise = Promise.promise();
     LOGGER.trace(cacheType + " refreshCache() called");
     String query = Constants.SELECT_UNIQUE_ATTRIBUTE;
     postgresService.executeQuery(query, handler -> {
@@ -55,12 +60,29 @@ public class UniqueAttributeCache implements IudxCache {
           JsonObject clientInfo = (JsonObject) e;
           String key = clientInfo.getString("resource_id");
           String value = clientInfo.getString("unique_attribute");
-          this.cache.put(key, value);
+          CacheValue<JsonObject> cacheValue=createCacheValue(key, value);
+          this.cache.put(key, cacheValue);
         });
-
+        promise.complete();
+      } else {
+        promise.fail("failed to refreash");
       }
     });
-
+    return promise.future();
+  }
+  
+  @Override
+  public CacheValue<JsonObject> createCacheValue(String id, String unique_attrib){
+    return new CacheValue<JsonObject>() {
+      @Override
+      public JsonObject getValue() {
+        JsonObject value=new JsonObject();
+        value.put("resource_id", id);
+        value.put("unique_attribute", unique_attrib);
+        return value;
+      }
+      
+    };
   }
 
 }

--- a/src/main/java/iudx/resource/server/cache/package-info.java
+++ b/src/main/java/iudx/resource/server/cache/package-info.java
@@ -1,5 +1,5 @@
 @ModuleGen(groupPackage = "iudx.resource.server.cache",
-  name = "iudx-resource-cache-service")
+  name = "iudx-resource-cache-service", useFutures = true)
 package iudx.resource.server.cache;
 
 import io.vertx.codegen.annotations.ModuleGen;

--- a/src/main/java/iudx/resource/server/database/latest/LatestDataServiceImpl.java
+++ b/src/main/java/iudx/resource/server/database/latest/LatestDataServiceImpl.java
@@ -123,14 +123,13 @@ public class LatestDataServiceImpl implements LatestDataService {
     JsonObject requestJson = new JsonObject();
     requestJson.put("type", CacheType.UNIQUE_ATTRIBUTE);
     requestJson.put("key", id);
-    cache.get(requestJson, handler -> {
-      if (handler.succeeded()) {
-        JsonObject json = handler.result();
-        promise.complete(json);
-      } else {
-        LOGGER.info("unique attribute doesn't exist for id : " + id);
-        promise.fail("unique attribute doesn't exist for id : " + id);
-      }
+    
+    Future<JsonObject> cacheFuture=cache.get(requestJson);
+    cacheFuture.onSuccess(successHandler->{
+      promise.complete(successHandler);
+    }).onFailure(failureHandler->{
+      LOGGER.info("unique attribute doesn't exist for id : " + id);
+      promise.fail("unique attribute doesn't exist for id : " + id);
     });
     return promise.future();
   }

--- a/src/main/java/iudx/resource/server/databroker/listeners/RevokeClientQListener.java
+++ b/src/main/java/iudx/resource/server/databroker/listeners/RevokeClientQListener.java
@@ -56,12 +56,11 @@ public class RevokeClientQListener implements RMQListeners {
                 cacheJson.put("key", key);
                 cacheJson.put("value", value);
 
-                cache.refresh(cacheJson, cacheHandler -> {
-                  if (cacheHandler.succeeded()) {
-                    LOGGER.debug("revoked client message published to Cache Verticle");
-                  } else {
-                    LOGGER.debug("revoked client message published to Cache Verticle fail");
-                  }
+                Future<JsonObject> cacheFuture=cache.refresh(cacheJson);
+                cacheFuture.onSuccess(successHandler->{
+                  LOGGER.debug("revoked client message published to Cache Verticle");
+                }).onFailure(failureHandler->{
+                  LOGGER.debug("revoked client message published to Cache Verticle fail");
                 });
               } else {
                 LOGGER.error("Empty json received from revoke_token queue");

--- a/src/main/java/iudx/resource/server/databroker/listeners/UniqueAttribQListener.java
+++ b/src/main/java/iudx/resource/server/databroker/listeners/UniqueAttribQListener.java
@@ -68,13 +68,13 @@ public class UniqueAttribQListener implements RMQListeners {
                   cacheJson.put("value", value);
                 }
 
-                cache.refresh(cacheJson, cacheHandler -> {
-                  if (cacheHandler.succeeded()) {
-                    LOGGER.debug("unique attrib message published to Cache Verticle");
-                  } else {
-                    LOGGER.debug("unique attrib message published to Cache Verticle fail");
-                  }
+                Future<JsonObject> cacheFuture=cache.refresh(cacheJson);
+                cacheFuture.onSuccess(successHandler->{
+                  LOGGER.debug("unique attrib message published to Cache Verticle");
+                }).onFailure(failureHandler->{
+                  LOGGER.debug("unique attrib message published to Cache Verticle fail");
                 });
+                
               } else {
                 LOGGER.info("Empty json received from revoke_token queue");
               }

--- a/src/test/java/iudx/resource/server/apiserver/handlers/FailureHandlerTest.java
+++ b/src/test/java/iudx/resource/server/apiserver/handlers/FailureHandlerTest.java
@@ -49,10 +49,10 @@ public class FailureHandlerTest {
         FailureHandler failureHandler = new FailureHandler();
         failureHandler.handle(routingContext);
 
-        verify(routingContext,times(2)).response();
-        verify(httpServerResponse, times(2)).putHeader(anyString(),anyString());
-        verify(httpServerResponse, times(2)).setStatusCode(400);
-        verify(httpServerResponse, times(2)).end(anyString());
+        verify(routingContext,atLeast(2)).response();
+        verify(httpServerResponse, atLeast(2)).putHeader(anyString(),anyString());
+        verify(httpServerResponse, atLeast(2)).setStatusCode(400);
+        verify(httpServerResponse, atLeast(2)).end(anyString());
 
 
         assertEquals("Dummy Message", dxRuntimeException.getMessage());

--- a/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceImplTest.java
+++ b/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceImplTest.java
@@ -958,11 +958,11 @@ public class JwtAuthServiceImplTest {
   
   
   @Test
-  @DisplayName("Test isOpenResource method for Group level ACL")
-  public void testIsOpenResourceGroupNoResourceId(VertxTestContext vertxTestContext)
+  @DisplayName("Test isOpenResource method for Group level ACL, but no resource id")
+  public void testIsOpenResourceGroupNoResourceIdExist(VertxTestContext vertxTestContext)
   {
 
-    String id = "datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/rs.iudx.io/pune-env-flood/FWR053";
+    String id = "datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/rs.iudx.io/pune-env-flood/non-existing";
     String[] idComponents = id.split("/");
     String groupId =(idComponents.length == 4)? id:String.join("/", Arrays.copyOfRange(idComponents, 0, 4));
     
@@ -977,9 +977,64 @@ public class JwtAuthServiceImplTest {
 
     jwtAuthenticationService.isOpenResource(id).onComplete(handler -> {
       if (handler.succeeded()) {
+        vertxTestContext.failNow(handler.cause());
+      } else {
+        vertxTestContext.completeNow();
+      }
+    });
+  }
+  
+  @Test
+  @DisplayName("Test isOpenResource method for Group level ACL")
+  public void testIsOpenResourceGroupNoACL4ResourceId(VertxTestContext vertxTestContext)
+  {
+
+    String id = "datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/rs.iudx.io/pune-env-flood/FWR053";
+    String[] idComponents = id.split("/");
+    String groupId =(idComponents.length == 4)? id:String.join("/", Arrays.copyOfRange(idComponents, 0, 4));
+    
+    JsonObject openResourceIdJson=new JsonObject();
+    openResourceIdJson.put("type", CacheType.CATALOGUE_CACHE);
+    openResourceIdJson.put("key", id);
+    when(cacheService.get(openResourceIdJson)).thenReturn(Future.succeededFuture(new JsonObject()));
+    
+    JsonObject openGroupIdJson=openResourceIdJson.copy();
+    openGroupIdJson.put("key", groupId);
+    when(cacheService.get(openGroupIdJson)).thenReturn(Future.succeededFuture(new JsonObject().put("accessPolicy", "OPEN")));
+
+    jwtAuthenticationService.isOpenResource(id).onComplete(handler -> {
+      if (handler.succeeded()) {
         vertxTestContext.completeNow();
       } else {
         vertxTestContext.failNow(handler.cause());
+      }
+    });
+  }
+  
+  @Test
+  @DisplayName("Test No ACL at group and resource level")
+  public void testNoACL(VertxTestContext vertxTestContext)
+  {
+
+    String id = "datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/rs.iudx.io/pune-env-flood/FWR053";
+    String[] idComponents = id.split("/");
+    String groupId =(idComponents.length == 4)? id:String.join("/", Arrays.copyOfRange(idComponents, 0, 4));
+    
+    JsonObject openResourceIdJson=new JsonObject();
+    openResourceIdJson.put("type", CacheType.CATALOGUE_CACHE);
+    openResourceIdJson.put("key", id);
+    when(cacheService.get(openResourceIdJson)).thenReturn(Future.succeededFuture(new JsonObject()));
+    
+    JsonObject openGroupIdJson=openResourceIdJson.copy();
+    openGroupIdJson.put("key", groupId);
+    when(cacheService.get(openGroupIdJson)).thenReturn(Future.succeededFuture(new JsonObject()));
+
+    jwtAuthenticationService.isOpenResource(id).onComplete(handler -> {
+      if (handler.succeeded()) {
+        vertxTestContext.failNow(handler.cause());
+      } else {
+        vertxTestContext.completeNow();
+        
       }
     });
   }

--- a/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceImplTest.java
+++ b/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceImplTest.java
@@ -9,10 +9,11 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
+import java.util.Arrays;
 import iudx.resource.server.common.Api;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.joda.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 import io.micrometer.core.ipc.http.HttpSender.Method;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -39,6 +41,8 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import iudx.resource.server.authenticator.model.JwtData;
 import iudx.resource.server.cache.CacheService;
+import iudx.resource.server.cache.cacheImpl.CacheType;
+import iudx.resource.server.cache.cacheImpl.IudxCache;
 import iudx.resource.server.configuration.Configuration;
 import iudx.resource.server.database.postgres.PostgresService;
 import iudx.resource.server.metering.MeteringService;
@@ -112,23 +116,41 @@ public class JwtAuthServiceImplTest {
     closeId =
             "iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/surat-itms-realtime-information";
     invalidId = "example.com/79e7bfa62fad6c765bac69154c2f24c94c95220a/resource-group1";
+//    iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/surat-itms-realtime-information
 
-    jwtAuthenticationService.resourceIdCache.put(openId, "OPEN");
-    jwtAuthenticationService.resourceIdCache.put(closeId, "CLOSED");
-    jwtAuthenticationService.resourceIdCache.put(invalidId, "CLOSED");
-    AsyncResult<JsonObject> asyncResult = mock(AsyncResult.class);
-    when(asyncResult.succeeded()).thenReturn(false);
+//    jwtAuthenticationService.resourceIdCache.put(openId, "OPEN");
+//    jwtAuthenticationService.resourceIdCache.put(closeId, "CLOSED");
+//    jwtAuthenticationService.resourceIdCache.put(invalidId, "CLOSED");
+//    AsyncResult<JsonObject> asyncResult = mock(AsyncResult.class);
+//    when(asyncResult.succeeded()).thenReturn(false);
 
-    Mockito.doAnswer(new Answer<AsyncResult<JsonObject>>() {
-      @SuppressWarnings("unchecked")
-      @Override
-      public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-        ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(asyncResult);
-        return null;
-      }
-    }).when(cacheService).get(any(), any());
-
-
+//    Mockito.doAnswer(new Answer<AsyncResult<JsonObject>>() {
+//      @SuppressWarnings("unchecked")
+//      @Override
+//      public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
+//        ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(asyncResult);
+//        return null;
+//      }
+//    }).when(cacheService).get(any());
+    
+    when(cacheService.get(any())).thenReturn(Future.failedFuture("failed"));
+    
+    JsonObject openIdJson=new JsonObject();
+    openIdJson.put("type", CacheType.CATALOGUE_CACHE);
+    openIdJson.put("key", openId);
+    when(cacheService.get(openIdJson)).thenReturn(Future.succeededFuture(new JsonObject().put("accessPolicy", "OPEN")));
+    
+    JsonObject closedIdJson=new JsonObject();
+    closedIdJson.put("type", CacheType.CATALOGUE_CACHE);
+    closedIdJson.put("key", closeId);
+    when(cacheService.get(closedIdJson)).thenReturn(Future.succeededFuture(new JsonObject().put("accessPolicy", "SECURE")));
+    
+    JsonObject invalidIdJson=new JsonObject();
+    invalidIdJson.put("type", CacheType.CATALOGUE_CACHE);
+    invalidIdJson.put("key", invalidId);
+    when(cacheService.get(invalidIdJson)).thenReturn(Future.failedFuture("Failed future"));
+    
+    
     LOGGER.info("Auth tests setup complete");
 
     testContext.completeNow();
@@ -183,7 +205,13 @@ public class JwtAuthServiceImplTest {
     authInfo.put("method", Method.GET);
 
     JsonObject request = new JsonObject();
-
+    
+    when(cacheService.get(any())).thenReturn(Future.failedFuture(""));
+    
+    JsonObject closedIdJson=new JsonObject();
+    closedIdJson.put("type", CacheType.CATALOGUE_CACHE);
+    closedIdJson.put("key", closeId);
+    when(cacheService.get(closedIdJson)).thenReturn(Future.succeededFuture(new JsonObject().put("accessPolicy", "SECURE")));
 
     jwtAuthenticationService.tokenInterospect(request, authInfo, handler -> {
       if (handler.succeeded()) {
@@ -251,6 +279,13 @@ public class JwtAuthServiceImplTest {
     authInfo.put("id", openId);
     authInfo.put("apiEndpoint", apis.getSubscriptionUrl());
     authInfo.put("method", Method.POST);
+    
+    when(cacheService.get(any())).thenReturn(Future.failedFuture("failed"));
+    
+    JsonObject openIdJson=new JsonObject();
+    openIdJson.put("type", CacheType.CATALOGUE_CACHE);
+    openIdJson.put("key", openId);
+    when(cacheService.get(openIdJson)).thenReturn(Future.succeededFuture(new JsonObject().put("accessPolicy", "OPEN")));
 
     jwtAuthenticationService.tokenInterospect(request, authInfo, handler -> {
       if (handler.succeeded()) {
@@ -775,334 +810,178 @@ public class JwtAuthServiceImplTest {
       }
     });
   }
+  
+  
+  
   @Test
-  @DisplayName("Testing Success for isItemExist method with List of String IDs")
-  public void testIsItemExistSuccess(VertxTestContext vertxTestContext)
-  {
-    JwtAuthenticationServiceImpl.catWebClient=mock(WebClient.class);
-    when(JwtAuthenticationServiceImpl.catWebClient.get(anyInt(),anyString(),anyString())).thenReturn(httpRequest);
-    when(httpRequest.addQueryParam(anyString(),anyString())).thenReturn(httpRequest);
-    when(httpRequest.expect(any())).thenReturn(httpRequest);
-    when(asyncResult.succeeded()).thenReturn(true);
-    when(asyncResult.result()).thenReturn(httpResponse);
-    String id="abcd/*";
-    JsonObject responseJSonObject = new JsonObject();
-    responseJSonObject.put("status","success");
-    responseJSonObject.put("totalHits", 10);
-    when(httpResponse.bodyAsJsonObject()).thenReturn(responseJSonObject);
-    doAnswer(new Answer<AsyncResult<HttpResponse<Buffer>>>() {
-      @Override
-      public AsyncResult<HttpResponse<Buffer>> answer(InvocationOnMock arg0) throws Throwable {
-
-        ((Handler<AsyncResult<HttpResponse<Buffer>>>)arg0.getArgument(0)).handle(asyncResult);
-        return null;
-      }
-    }).when(httpRequest).send(any());
-    jwtAuthenticationService.isItemExist(id).onComplete(handler -> {
-      if (handler.succeeded())
-      {
-        assertTrue(handler.result());
-        vertxTestContext.completeNow();
-      }
-      else
-      {
-        vertxTestContext.failNow(handler.cause());
+  @DisplayName("Revoked token passed")
+  public void testRevokedTokenPassed(VertxTestContext testContext) {
+    JwtData jwtData = new JwtData();
+    jwtData.setSub("valid_sub");
+    jwtData.setIss("auth.test.com");
+    jwtData.setAud("rs.iudx.io");
+    jwtData.setExp(1627408865);
+    jwtData.setIat(1627408865);
+    jwtData.setIid("rg:example.com/79e7bfa62fad6c765bac69154c2f24c94c95220a/resource-group");
+    jwtData.setRole("provider");
+    jwtData.setCons(new JsonObject().put("access", new JsonArray().add("api")));
+    
+    JsonObject revokedTokenRequest=new JsonObject();
+    revokedTokenRequest.put("type", CacheType.REVOKED_CLIENT);
+    revokedTokenRequest.put("key", jwtData.getSub());
+    
+    when(cacheService.get(revokedTokenRequest)).thenReturn(Future.succeededFuture(new JsonObject().put("value", LocalDateTime.now().minusDays(1).toString())));
+    
+    jwtAuthenticationService.isRevokedClientToken(jwtData).onComplete(handler->{
+      if(handler.succeeded()) {
+        testContext.failNow("access provided for revoked token");
+      }else {
+        testContext.completeNow();
       }
     });
+    
   }
+  
+  
   @Test
-  @DisplayName("Testing Failure for isItemExist method with List of String IDs")
-  public void testIsItemExistFailure(VertxTestContext vertxTestContext)
-  {
-    JwtAuthenticationServiceImpl.catWebClient= mock(WebClient.class);
-    when(JwtAuthenticationServiceImpl.catWebClient.get(anyInt(),anyString(),anyString())).thenReturn(httpRequest);
-    when(httpRequest.addQueryParam(anyString(),anyString())).thenReturn(httpRequest);
-    when(httpRequest.expect(any())).thenReturn(httpRequest);
-    String id="abcd/*";
-    when(asyncResult.succeeded()).thenReturn(false);
-    doAnswer(new Answer<AsyncResult<HttpResponse<Buffer>>>() {
-      @Override
-      public AsyncResult<HttpResponse<Buffer>> answer(InvocationOnMock arg0) throws Throwable {
-
-        ((Handler<AsyncResult<HttpResponse<Buffer>>>)arg0.getArgument(0)).handle(asyncResult);
-        return null;
-      }
-    }).when(httpRequest).send(any());
-    jwtAuthenticationService.isItemExist(id).onComplete(handler -> {
-      if (handler.succeeded())
-      {
-        vertxTestContext.failNow(handler.cause());
-      }
-      else
-      {
-        vertxTestContext.completeNow();
+  @DisplayName("correct unrevoked token passed")
+  public void testCorrectUnrevokedTokenPassed(VertxTestContext testContext) {
+    JwtData jwtData = new JwtData();
+    jwtData.setSub("valid_sub");
+    jwtData.setIss("auth.test.com");
+    jwtData.setAud("rs.iudx.io");
+    jwtData.setExp(1676016492);
+    jwtData.setIat(1676016492);
+    jwtData.setIid("rg:example.com/79e7bfa62fad6c765bac69154c2f24c94c95220a/resource-group");
+    jwtData.setRole("provider");
+    jwtData.setCons(new JsonObject().put("access", new JsonArray().add("api")));
+    
+    JsonObject revokedTokenRequest=new JsonObject();
+    revokedTokenRequest.put("type", CacheType.REVOKED_CLIENT);
+    revokedTokenRequest.put("key", jwtData.getSub());
+    String time="2023-02-08T12:37:26.796"; 
+    when(cacheService.get(revokedTokenRequest)).thenReturn(Future.succeededFuture(new JsonObject().put("value", time)));
+    
+    
+    jwtAuthenticationService.isRevokedClientToken(jwtData).onComplete(handler->{
+      if(handler.succeeded()) {
+        testContext.completeNow();
+      }else {
+        testContext.failNow("no access for correct token");
       }
     });
-
+    
   }
+  
   @Test
   @DisplayName("Test isOpenResource method for Cache miss for Valid Group ID")
-  public void testIsOpenResource(VertxTestContext vertxTestContext)
+  public void testIsOpenResourceGroupId(VertxTestContext vertxTestContext)
   {
 
-    AsyncResult<HttpResponse<Buffer>> asyncResultMock = mock(AsyncResult.class);
-
-    JsonObject jsonObject2 = new JsonObject();
-    jsonObject2.put("accessPolicy", "Dummy Access Policy");
-    JsonArray jsonArray = new JsonArray();
-    jsonArray.add(0,jsonObject2);
-
-    JsonObject jsonObject = new JsonObject();
-    jsonObject.put("type", "urn:dx:cat:Success");
-    jsonObject.put("totalHits", 3);
-    jsonObject.put("results",jsonArray);
     String id = "datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/rs.iudx.io/pune-env-flood/FWR053";
+    String[] idComponents = id.split("/");
+    String groupId =(idComponents.length == 4)? id:String.join("/", Arrays.copyOfRange(idComponents, 0, 4));
+    
+    JsonObject openResourceIdJson=new JsonObject();
+    openResourceIdJson.put("type", CacheType.CATALOGUE_CACHE);
+    openResourceIdJson.put("key", id);
+    when(cacheService.get(openResourceIdJson)).thenReturn(Future.succeededFuture(new JsonObject()));
+    
+    JsonObject openGroupIdJson=openResourceIdJson.copy();
+    openGroupIdJson.put("key", groupId);
+    when(cacheService.get(openGroupIdJson)).thenReturn(Future.succeededFuture(new JsonObject().put("accessPolicy", "OPEN")));
 
-
-    jwtAuthenticationService.catWebClient = mock(WebClient.class);
-
-    when(jwtAuthenticationService.catWebClient.get(anyInt(),anyString(),anyString())).thenReturn(httpRequestMock);
-    when(httpRequestMock.addQueryParam(anyString(),anyString())).thenReturn(httpRequestMock);
-    when(httpRequestMock.expect(any())).thenReturn(httpRequestMock);
-    when(asyncResultMock.result()).thenReturn(httpResponseMock);
-    when(httpResponseMock.statusCode()).thenReturn(200);
-
-    when(httpResponseMock.bodyAsJsonObject()).thenReturn(jsonObject);
-    doAnswer(new Answer<AsyncResult<HttpResponse<Buffer>>>(){
-      @Override
-      public AsyncResult<HttpResponse<Buffer>> answer(InvocationOnMock arg0) throws Throwable{
-        (  (Handler<AsyncResult<HttpResponse<Buffer>>>)arg0.getArgument(0)).handle(asyncResultMock);
-        return null;
-      }
-    }).when(httpRequestMock).send(any());
-    jwtAuthenticationService.isOpenResource(id).onComplete(openResourceHandler -> {
-      if(openResourceHandler.succeeded()) {
-        assertEquals("Dummy Access Policy",openResourceHandler.result());
+    jwtAuthenticationService.isOpenResource(id).onComplete(handler -> {
+      if (handler.succeeded()) {
         vertxTestContext.completeNow();
       } else {
-        vertxTestContext.failNow("open resource validation failed : " + openResourceHandler.cause());
-
+        vertxTestContext.failNow(handler.cause());
       }
     });
   }
+  
+  
   @Test
-  @DisplayName("Test isOpenResource method for Cache miss with 0 total hits")
-  public void testIsOpenResourceWith0TotalHits(VertxTestContext vertxTestContext)
+  @DisplayName("Test isOpenResource method for Cache miss for Valid Group ID")
+  public void testIsOpenResourceId(VertxTestContext vertxTestContext)
   {
 
-    AsyncResult<HttpResponse<Buffer>> asyncResultMock = mock(AsyncResult.class);
-
-    JsonObject jsonObject2 = new JsonObject();
-    jsonObject2.put("accessPolicy", "Dummy Access Policy");
-    JsonArray jsonArray = new JsonArray();
-    jsonArray.add(0,jsonObject2);
     String id = "datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/rs.iudx.io/pune-env-flood/FWR053";
-    JsonObject jsonObject = new JsonObject();
-    jsonObject.put("type", "urn:dx:cat:Success");
-    jsonObject.put("totalHits", 0);
-    jsonObject.put("results",jsonArray);
-    jwtAuthenticationService.catWebClient = mock(WebClient.class);
-    when(jwtAuthenticationService.catWebClient.get(anyInt(),anyString(),anyString())).thenReturn(httpRequestMock);
-    when(httpRequestMock.addQueryParam(anyString(),anyString())).thenReturn(httpRequestMock);
-    when(httpRequestMock.expect(any())).thenReturn(httpRequestMock);
-    when(asyncResultMock.result()).thenReturn(httpResponseMock);
-    when(httpResponseMock.statusCode()).thenReturn(200);
+    String[] idComponents = id.split("/");
+    String groupId =(idComponents.length == 4)? id:String.join("/", Arrays.copyOfRange(idComponents, 0, 4));
+    
+    JsonObject openResourceIdJson=new JsonObject();
+    openResourceIdJson.put("type", CacheType.CATALOGUE_CACHE);
+    openResourceIdJson.put("key", id);
+    when(cacheService.get(openResourceIdJson)).thenReturn(Future.succeededFuture(new JsonObject().put("accessPolicy", "OPEN")));
+    
+    JsonObject openGroupIdJson=openResourceIdJson.copy();
+    openGroupIdJson.put("key", groupId);
+    when(cacheService.get(openGroupIdJson)).thenReturn(Future.succeededFuture(new JsonObject()));
 
-    when(httpResponseMock.bodyAsJsonObject()).thenReturn(jsonObject);
-
-    doAnswer(new Answer<AsyncResult<HttpResponse<Buffer>>>(){
-      @Override
-      public AsyncResult<HttpResponse<Buffer>> answer(InvocationOnMock arg0) throws Throwable{
-        (  (Handler<AsyncResult<HttpResponse<Buffer>>>)arg0.getArgument(0)).handle(asyncResultMock);
-        return null;
-      }
-    }).when(httpRequestMock).send(any());
-
-    jwtAuthenticationService.isOpenResource(id).onComplete(openResourceHandler -> {
-      if(openResourceHandler.succeeded()) {
-        vertxTestContext.failNow("open resource validation failed : " + openResourceHandler.cause());
-      } else {
-        assertNull(openResourceHandler.result());
+    jwtAuthenticationService.isOpenResource(id).onComplete(handler -> {
+      if (handler.succeeded()) {
         vertxTestContext.completeNow();
+      } else {
+        vertxTestContext.failNow(handler.cause());
       }
     });
   }
+  
+  
   @Test
-  @DisplayName("Testing Failure for isResourceExist method with List of String IDs")
-  public void testIsResourceExistFailure(VertxTestContext vertxTestContext)
+  @DisplayName("Test isOpenResource method for Resource level ACL [No entry for resource Id]")
+  public void testIsOpenResourceIdNoGroupId(VertxTestContext vertxTestContext)
   {
-    String id="Dummy id";
-    String groupACL="Dummy id";
-    JsonObject responseJSonObject=new JsonObject();
-    responseJSonObject.put("type","urn:dx:cat:Success");
-    responseJSonObject.put("totalHits", 10);
-    JwtAuthenticationServiceImpl.catWebClient=mock(WebClient.class);
-    when(JwtAuthenticationServiceImpl.catWebClient.get(anyInt(),anyString(),anyString())).thenReturn(httpRequest);
-    when(httpRequest.addQueryParam(anyString(),anyString())).thenReturn(httpRequest);
-    when(httpRequest.expect(any())).thenReturn(httpRequest);
-    when(asyncResult.result()).thenReturn(httpResponse);
-    when(httpResponse.bodyAsJsonObject()).thenReturn(responseJSonObject);
-    when(httpResponse.statusCode()).thenReturn(400);
-    doAnswer(new Answer<AsyncResult<HttpResponse<Buffer>>>() {
-      @Override
-      public AsyncResult<HttpResponse<Buffer>> answer(InvocationOnMock arg0) throws Throwable {
 
-        ((Handler<AsyncResult<HttpResponse<Buffer>>>)arg0.getArgument(0)).handle(asyncResult);
-        return null;
-      }
-    }).when(httpRequest).send(any());
-    jwtAuthenticationService.isResourceExist(id,groupACL).onComplete(handler -> {
-      if (handler.succeeded())
-      {
-        vertxTestContext.failNow("false");
-      }
-      else
-      {
+    String id = "datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/rs.iudx.io/pune-env-flood/FWR053";
+    String[] idComponents = id.split("/");
+    String groupId =(idComponents.length == 4)? id:String.join("/", Arrays.copyOfRange(idComponents, 0, 4));
+    
+    JsonObject openResourceIdJson=new JsonObject();
+    openResourceIdJson.put("type", CacheType.CATALOGUE_CACHE);
+    openResourceIdJson.put("key", id);
+    when(cacheService.get(openResourceIdJson)).thenReturn(Future.succeededFuture(new JsonObject().put("accessPolicy", "OPEN")));
+    
+    JsonObject openGroupIdJson=openResourceIdJson.copy();
+    openGroupIdJson.put("key", groupId);
+    when(cacheService.get(openGroupIdJson)).thenReturn(Future.failedFuture("failed for group id"));
+
+    jwtAuthenticationService.isOpenResource(id).onComplete(handler -> {
+      if (handler.succeeded()) {
         vertxTestContext.completeNow();
+      } else {
+        vertxTestContext.failNow(handler.cause());
       }
     });
   }
+  
+  
   @Test
-  @DisplayName("Testing Failure for isResourceExist method with List of String IDs")
-  public void testIsResourceExistFailure2(VertxTestContext vertxTestContext)
+  @DisplayName("Test isOpenResource method for Group level ACL")
+  public void testIsOpenResourceGroupNoResourceId(VertxTestContext vertxTestContext)
   {
-    String id="Dummy id";
-    String groupACL="Dummy id";
-    JsonObject responseJSonObject=new JsonObject();
-    responseJSonObject.put("type","dummy");
-    responseJSonObject.put("totalHits", 10);
-    JwtAuthenticationServiceImpl.catWebClient=mock(WebClient.class);
-    when(JwtAuthenticationServiceImpl.catWebClient.get(anyInt(),anyString(),anyString())).thenReturn(httpRequest);
-    when(httpRequest.addQueryParam(anyString(),anyString())).thenReturn(httpRequest);
-    when(httpRequest.expect(any())).thenReturn(httpRequest);
-    when(asyncResult.result()).thenReturn(httpResponse);
-    when(httpResponse.bodyAsJsonObject()).thenReturn(responseJSonObject);
-    when(httpResponse.statusCode()).thenReturn(200);
-    doAnswer(new Answer<AsyncResult<HttpResponse<Buffer>>>() {
-      @Override
-      public AsyncResult<HttpResponse<Buffer>> answer(InvocationOnMock arg0) throws Throwable {
 
-        ((Handler<AsyncResult<HttpResponse<Buffer>>>)arg0.getArgument(0)).handle(asyncResult);
-        return null;
-      }
-    }).when(httpRequest).send(any());
-    jwtAuthenticationService.isResourceExist(id,groupACL).onComplete(handler -> {
-      if (handler.succeeded())
-      {
-        vertxTestContext.failNow("Not Found");
-      }
-      else
-      {
-        vertxTestContext.completeNow();
-      }
-    });
-  }
-  @Test
-  @DisplayName("Testing Failure for isResourceExist method with List of String IDs")
-  public void testIsResourceExistFailure3(VertxTestContext vertxTestContext) {
-    String id = "Dummy id";
-    String groupACL = "Dummy id";
-    String resourceACL="SECURE";
-    JsonObject responseJSonObject = new JsonObject();
-    JsonArray jsonarray=new JsonArray();
-    responseJSonObject.put("type", "wrong type");
-    responseJSonObject.put("totalHits", 10);
-//   resourceACL=responseJSonObject.getJsonArray("results").getJsonObject(0).getString("accessPolicy");
-    JwtAuthenticationServiceImpl.catWebClient = mock(WebClient.class);
-    when(JwtAuthenticationServiceImpl.catWebClient.get(anyInt(), anyString(), anyString())).thenReturn(httpRequest);
-    when(httpRequest.addQueryParam(anyString(), anyString())).thenReturn(httpRequest);
-    when(httpRequest.expect(any())).thenReturn(httpRequest);
-    when(asyncResult.result()).thenReturn(httpResponse);
-    when(httpResponse.bodyAsJsonObject()).thenReturn(responseJSonObject);
-    when(httpResponse.statusCode()).thenReturn(200);
+    String id = "datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/rs.iudx.io/pune-env-flood/FWR053";
+    String[] idComponents = id.split("/");
+    String groupId =(idComponents.length == 4)? id:String.join("/", Arrays.copyOfRange(idComponents, 0, 4));
+    
+    JsonObject openResourceIdJson=new JsonObject();
+    openResourceIdJson.put("type", CacheType.CATALOGUE_CACHE);
+    openResourceIdJson.put("key", id);
+    when(cacheService.get(openResourceIdJson)).thenReturn(Future.failedFuture("failed for resource id"));
+    
+    JsonObject openGroupIdJson=openResourceIdJson.copy();
+    openGroupIdJson.put("key", groupId);
+    when(cacheService.get(openGroupIdJson)).thenReturn(Future.succeededFuture(new JsonObject().put("accessPolicy", "OPEN")));
 
-
-    doAnswer(new Answer<AsyncResult<HttpResponse<Buffer>>>() {
-      @Override
-      public AsyncResult<HttpResponse<Buffer>> answer(InvocationOnMock arg0) throws Throwable {
-
-        ((Handler<AsyncResult<HttpResponse<Buffer>>>) arg0.getArgument(0)).handle(asyncResult);
-        return null;
-      }
-    }).when(httpRequest).send(any());
-    jwtAuthenticationService.isResourceExist(id, groupACL).onComplete(handler -> {
+    jwtAuthenticationService.isOpenResource(id).onComplete(handler -> {
       if (handler.succeeded()) {
-        vertxTestContext.failNow("Not Found");
-      } else {
         vertxTestContext.completeNow();
+      } else {
+        vertxTestContext.failNow(handler.cause());
       }
     });
   }
-  @Test
-  @DisplayName("Testing Failure for isResourceExist method with List of String IDs")
-  public void testGroupAccessPolicyFailure2(VertxTestContext vertxTestContext) {
-    String id = "datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/rs.iudx.io/pune-env-flood/FWR053";    String groupACL = "Dummy id";
-    String resourceACL="SECURE";
-    JsonObject responseJSonObject = new JsonObject();
-    JsonArray jsonarray=new JsonArray();
-    responseJSonObject.put("type", "urn:dx:cat:Success");
-    responseJSonObject.put("totalHits", 10);
-//   resourceACL=responseJSonObject.getJsonArray("results").getJsonObject(0).getString("accessPolicy");
-    JwtAuthenticationServiceImpl.catWebClient = mock(WebClient.class);
-    when(JwtAuthenticationServiceImpl.catWebClient.get(anyInt(), anyString(), anyString())).thenReturn(httpRequest);
-    when(httpRequest.addQueryParam(anyString(), anyString())).thenReturn(httpRequest);
-    when(httpRequest.expect(any())).thenReturn(httpRequest);
-    when(asyncResult.result()).thenReturn(httpResponse);
-//    when(httpResponse.bodyAsJsonObject()).thenReturn(responseJSonObject);
-    when(httpResponse.statusCode()).thenReturn(400);
-
-
-    doAnswer(new Answer<AsyncResult<HttpResponse<Buffer>>>() {
-      @Override
-      public AsyncResult<HttpResponse<Buffer>> answer(InvocationOnMock arg0) throws Throwable {
-
-        ((Handler<AsyncResult<HttpResponse<Buffer>>>) arg0.getArgument(0)).handle(asyncResult);
-        return null;
-      }
-    }).when(httpRequest).send(any());
-    jwtAuthenticationService.getGroupAccessPolicy(id).onComplete(handler -> {
-      if (handler.succeeded()) {
-        vertxTestContext.failNow("Not Found");
-      } else {
-        vertxTestContext.completeNow();
-      }
-    });
-  }
-  @Test
-  @DisplayName("Testing Failure for isResourceExist method with List of String IDs")
-  public void testGroupAccessPolicyFailure(VertxTestContext vertxTestContext) {
-    String id = "datakaveri.org/04a15c9960ffda227e9546f3f46e629e1fe4132b/rs.iudx.io/pune-env-flood/FWR053";    String groupACL = "Dummy id";
-    String resourceACL="SECURE";
-    JsonObject responseJSonObject = new JsonObject();
-    JsonArray jsonarray=new JsonArray();
-    responseJSonObject.put("type", "wrong type");
-    responseJSonObject.put("totalHits", 10);
-//   resourceACL=responseJSonObject.getJsonArray("results").getJsonObject(0).getString("accessPolicy");
-    JwtAuthenticationServiceImpl.catWebClient = mock(WebClient.class);
-    when(JwtAuthenticationServiceImpl.catWebClient.get(anyInt(), anyString(), anyString())).thenReturn(httpRequest);
-    when(httpRequest.addQueryParam(anyString(), anyString())).thenReturn(httpRequest);
-    when(httpRequest.expect(any())).thenReturn(httpRequest);
-    when(asyncResult.result()).thenReturn(httpResponse);
-    when(httpResponse.bodyAsJsonObject()).thenReturn(responseJSonObject);
-    when(httpResponse.statusCode()).thenReturn(200);
-
-
-    doAnswer(new Answer<AsyncResult<HttpResponse<Buffer>>>() {
-      @Override
-      public AsyncResult<HttpResponse<Buffer>> answer(InvocationOnMock arg0) throws Throwable {
-
-        ((Handler<AsyncResult<HttpResponse<Buffer>>>) arg0.getArgument(0)).handle(asyncResult);
-        return null;
-      }
-    }).when(httpRequest).send(any());
-    jwtAuthenticationService.getGroupAccessPolicy(id).onComplete(handler -> {
-      if (handler.succeeded()) {
-        vertxTestContext.failNow("Not Found");
-      } else {
-        vertxTestContext.completeNow();
-      }
-    });
-  }
-
 
 }

--- a/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceTest.java
+++ b/src/test/java/iudx/resource/server/authenticator/JwtAuthServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -87,18 +88,9 @@ public class JwtAuthServiceTest {
         JsonObject jsonObject = new JsonObject();
         jsonObject.put("value", "2022-06-13T17:20:00.330");
         when(jwtData.getSub()).thenReturn("Dummy ID");
-        when(asyncResult.succeeded()).thenReturn(true);
-        when(asyncResult.result()).thenReturn(jsonObject);
         when(jwtData.getIat()).thenReturn(3000);
 
-        doAnswer(new Answer<AsyncResult<JsonObject>>() {
-            @Override
-            public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-                ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(asyncResult);
-                return null;
-            }
-        }).when(cacheService).get(any(),any());
-
+        when(cacheService.get(any())).thenReturn(Future.succeededFuture(jsonObject));
         jwtAuthenticationService.isRevokedClientToken(jwtData).onComplete(handler -> {
             if(handler.succeeded())
             {
@@ -119,18 +111,18 @@ public class JwtAuthServiceTest {
         JsonObject jsonObject = new JsonObject();
         jsonObject.put("value", "1022-06-13T17:20:00.330");
         when(jwtData.getSub()).thenReturn("Dummy ID");
-        when(asyncResult.succeeded()).thenReturn(true);
-        when(asyncResult.result()).thenReturn(jsonObject);
+//        when(asyncResult.succeeded()).thenReturn(true);
+//        when(asyncResult.result()).thenReturn(jsonObject);
         when(jwtData.getIat()).thenReturn(952097820);
 
-        doAnswer(new Answer<AsyncResult<JsonObject>>() {
-            @Override
-            public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-                ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(asyncResult);
-                return null;
-            }
-        }).when(jwtAuthenticationService.cache).get(any(),any());
-
+//        doAnswer(new Answer<AsyncResult<JsonObject>>() {
+//            @Override
+//            public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
+//                ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(asyncResult);
+//                return null;
+//            }
+//        }).when(jwtAuthenticationService.cache).get(any());
+        when(cacheService.get(any())).thenReturn(Future.succeededFuture(jsonObject));
         jwtAuthenticationService.isRevokedClientToken(jwtData).onComplete(handler -> {
             if(handler.succeeded())
             {

--- a/src/test/java/iudx/resource/server/database/latest/LatestServiceTest.java
+++ b/src/test/java/iudx/resource/server/database/latest/LatestServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
@@ -69,18 +70,18 @@ public class LatestServiceTest {
             .put("id", new JsonArray().add(id))
             .put("searchType", "latestSearch");
 
-    AsyncResult<JsonObject> asyncResult = mock(AsyncResult.class);
-    when(asyncResult.succeeded()).thenReturn(false);
+//    AsyncResult<JsonObject> asyncResult = mock(AsyncResult.class);
+//    when(asyncResult.succeeded()).thenReturn(false);
 
-    Mockito.doAnswer(new Answer<AsyncResult<JsonObject>>() {
-      @SuppressWarnings("unchecked")
-      @Override
-      public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-        ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(asyncResult);
-        return null;
-      }
-    }).when(cacheService).get(any(), any());
-
+//    Mockito.doAnswer(new Answer<AsyncResult<JsonObject>>() {
+//      @SuppressWarnings("unchecked")
+//      @Override
+//      public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
+//        ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(asyncResult);
+//        return null;
+//      }
+//    }).when(cacheService).get(any());
+    when(cacheService.get(any())).thenReturn(Future.failedFuture("failed"));
     latest.getLatestData(request, handler -> {
       if (handler.succeeded()) {
         LOGGER.debug("Got the data!");
@@ -101,18 +102,18 @@ public class LatestServiceTest {
             .put("id", new JsonArray().add(id))
             .put("searchType", "latestSearch");
 
-    AsyncResult<JsonObject> asyncResult = mock(AsyncResult.class);
-    when(asyncResult.succeeded()).thenReturn(false);
+//    AsyncResult<JsonObject> asyncResult = mock(AsyncResult.class);
+//    when(asyncResult.succeeded()).thenReturn(false);
 
-    Mockito.doAnswer(new Answer<AsyncResult<JsonObject>>() {
-      @SuppressWarnings("unchecked")
-      @Override
-      public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-        ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(asyncResult);
-        return null;
-      }
-    }).when(cacheService).get(any(), any());
-
+//    Mockito.doAnswer(new Answer<AsyncResult<JsonObject>>() {
+//      @SuppressWarnings("unchecked")
+//      @Override
+//      public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
+//        ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(asyncResult);
+//        return null;
+//      }
+//    }).when(cacheService).get(any());
+    when(cacheService.get(any())).thenReturn(Future.failedFuture("failed"));
     latest.getLatestData(request, handler -> {
       if (handler.succeeded()) {
         testContext.failNow(handler.cause());
@@ -136,19 +137,19 @@ public class LatestServiceTest {
     JsonObject cacheResponse = new JsonObject();
     cacheResponse.put("value", "license_plate");
 
-    AsyncResult<JsonObject> asyncResult = mock(AsyncResult.class);
-    when(asyncResult.succeeded()).thenReturn(true);
-    when(asyncResult.result()).thenReturn(cacheResponse);
+//    AsyncResult<JsonObject> asyncResult = mock(AsyncResult.class);
+//    when(asyncResult.succeeded()).thenReturn(true);
+//    when(asyncResult.result()).thenReturn(cacheResponse);
 
-    Mockito.doAnswer(new Answer<AsyncResult<JsonObject>>() {
-      @SuppressWarnings("unchecked")
-      @Override
-      public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-        ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(asyncResult);
-        return null;
-      }
-    }).when(cacheService).get(any(), any());
-
+//    Mockito.doAnswer(new Answer<AsyncResult<JsonObject>>() {
+//      @SuppressWarnings("unchecked")
+//      @Override
+//      public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
+//        ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(asyncResult);
+//        return null;
+//      }
+//    }).when(cacheService).get(any());
+    when(cacheService.get(any())).thenReturn(Future.succeededFuture(cacheResponse));
     latest.getLatestData(request, handler -> {
       if (handler.succeeded()) {
         LOGGER.debug("Got the data!");

--- a/src/test/java/iudx/resource/server/databroker/listeners/TestRevokeClientQListener.java
+++ b/src/test/java/iudx/resource/server/databroker/listeners/TestRevokeClientQListener.java
@@ -81,9 +81,7 @@ public class TestRevokeClientQListener {
     object.put("unique-attribute", "Dummy_unique-attribute");
     Buffer buffer = Buffer.buffer(object.toString());
     when(clientStartAsyncResult.succeeded()).thenReturn(true);
-    // when(voidFuture.succeeded()).thenReturn(true);
     when(message.body()).thenReturn(buffer);
-    when(jsonObjectAsyncResult.succeeded()).thenReturn(true);
 
 
     doAnswer(new Answer<AsyncResult<RabbitMQConsumer>>() {
@@ -101,13 +99,7 @@ public class TestRevokeClientQListener {
         return null;
       }
     }).when(rabbitMQConsumer).handler(any());
-    doAnswer(new Answer<AsyncResult<JsonObject>>() {
-      @Override
-      public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-        ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(jsonObjectAsyncResult);
-        return null;
-      }
-    }).when(cache).refresh(any(), any());
+    when(cache.refresh(any())).thenReturn(Future.succeededFuture(new JsonObject()));
     doAnswer(new Answer<AsyncResult<RabbitMQConsumer>>() {
       @Override
       public AsyncResult<RabbitMQConsumer> answer(InvocationOnMock arg0) throws Throwable {
@@ -119,7 +111,7 @@ public class TestRevokeClientQListener {
     revokeClientQListener.start();
     verify(voidFuture, times(1)).onComplete(any());
     verify(message).body();
-    verify(jsonObjectAsyncResult).succeeded();
+    verify(cache,times(1)).refresh(any());
     assertEquals(buffer, message.body());
     vertxTestContext.completeNow();
   }
@@ -138,9 +130,7 @@ public class TestRevokeClientQListener {
     object.put("unique-attribute", "Dummy_unique-attribute");
     Buffer buffer = Buffer.buffer(object.toString());
     when(clientStartAsyncResult.succeeded()).thenReturn(true);
-    // when(voidFuture.succeeded()).thenReturn(true);
     when(message.body()).thenReturn(buffer);
-    when(jsonObjectAsyncResult.succeeded()).thenReturn(false);
 
     doAnswer(new Answer<AsyncResult<RabbitMQConsumer>>() {
       @Override
@@ -157,13 +147,7 @@ public class TestRevokeClientQListener {
         return null;
       }
     }).when(rabbitMQConsumer).handler(any());
-    doAnswer(new Answer<AsyncResult<JsonObject>>() {
-      @Override
-      public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-        ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(jsonObjectAsyncResult);
-        return null;
-      }
-    }).when(cache).refresh(any(), any());
+    when(cache.refresh(any())).thenReturn(Future.failedFuture(""));
     doAnswer(new Answer<AsyncResult<RabbitMQConsumer>>() {
       @Override
       public AsyncResult<RabbitMQConsumer> answer(InvocationOnMock arg0) throws Throwable {
@@ -175,7 +159,7 @@ public class TestRevokeClientQListener {
     revokeClientQListener.start();
     verify(voidFuture, times(1)).onComplete(any());
     verify(message).body();
-    verify(jsonObjectAsyncResult).succeeded();
+    verify(cache,times(1)).refresh(any());
     assertEquals(buffer, message.body());
     vertxTestContext.completeNow();
   }

--- a/src/test/java/iudx/resource/server/databroker/listeners/TestUniqueAttribQListener.java
+++ b/src/test/java/iudx/resource/server/databroker/listeners/TestUniqueAttribQListener.java
@@ -84,7 +84,6 @@ public class TestUniqueAttribQListener {
     Buffer buffer = Buffer.buffer(object.toString());
     when(clientStartAsyncResult.succeeded()).thenReturn(true);
     when(message.body()).thenReturn(buffer);
-    when(jsonObjectAsyncResult.succeeded()).thenReturn(true);
 
 
     doAnswer(new Answer<AsyncResult<RabbitMQConsumer>>() {
@@ -102,13 +101,7 @@ public class TestUniqueAttribQListener {
         return null;
       }
     }).when(rabbitMQConsumer).handler(any());
-    doAnswer(new Answer<AsyncResult<JsonObject>>() {
-      @Override
-      public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-        ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(jsonObjectAsyncResult);
-        return null;
-      }
-    }).when(cache).refresh(any(), any());
+    when(cache.refresh(any())).thenReturn(Future.succeededFuture(new JsonObject()));
     doAnswer(new Answer<AsyncResult<RabbitMQConsumer>>() {
       @Override
       public AsyncResult<RabbitMQConsumer> answer(InvocationOnMock arg0) throws Throwable {
@@ -120,7 +113,7 @@ public class TestUniqueAttribQListener {
     uniqueAttribQListener.start();
     verify(voidFuture, times(1)).onComplete(any());
     verify(message).body();
-    verify(jsonObjectAsyncResult).succeeded();
+    verify(cache,times(1)).refresh(any());
     assertEquals(buffer, message.body());
     vertxTestContext.completeNow();
   }
@@ -141,7 +134,6 @@ public class TestUniqueAttribQListener {
     Buffer buffer = Buffer.buffer(object.toString());
     when(clientStartAsyncResult.succeeded()).thenReturn(true);
     when(message.body()).thenReturn(buffer);
-    when(jsonObjectAsyncResult.succeeded()).thenReturn(false);
 
     doAnswer(new Answer<AsyncResult<RabbitMQConsumer>>() {
       @Override
@@ -158,14 +150,7 @@ public class TestUniqueAttribQListener {
         return null;
       }
     }).when(rabbitMQConsumer).handler(any());
-    doAnswer(new Answer<AsyncResult<JsonObject>>() {
-      @Override
-      public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-        ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(jsonObjectAsyncResult);
-        return null;
-      }
-    }).when(cache).refresh(any(), any());
-
+    when(cache.refresh(any())).thenReturn(Future.failedFuture(""));
     doAnswer(new Answer<AsyncResult<RabbitMQConsumer>>() {
       @Override
       public AsyncResult<RabbitMQConsumer> answer(InvocationOnMock arg0) throws Throwable {
@@ -177,7 +162,7 @@ public class TestUniqueAttribQListener {
     uniqueAttribQListener.start();
     verify(voidFuture, times(1)).onComplete(any());
     verify(message).body();
-    verify(jsonObjectAsyncResult).succeeded();
+    verify(cache,times(1)).refresh(any());
     assertEquals(buffer, message.body());
     vertxTestContext.completeNow();
   }


### PR DESCRIPTION
- Refactoring for catalog cache
  - using /search instead of /item API [caching all items on startup]
  - an internal cache of 5000 items size.
- QueryMapper refactoring
  - doing a context.fail() instead of throwing an exception [since exceptions are not bounded to vert.x route when thrown from lambdas ] ([link](https://github.com/vert-x3/vertx-web/issues/1874))
- Cache Service changes
  - Moved from handler-based methods to Future based service definitions.
  - new CatalogueCacheImpl for catalog cache class.
 - Junits
   - Appropriate junits changes for above changes
