### PR TITLE
changes query according to requirement

### DIFF
--- a/src/main/java/iudx/resource/server/metering/util/Constants.java
+++ b/src/main/java/iudx/resource/server/metering/util/Constants.java
@@ -85,14 +85,23 @@ public class Constants {
   public static final StringBuilder RESPONSE_SIZE_COLUMN = new StringBuilder("size)");
 
   public static final StringBuilder ID_COLUMN = new StringBuilder("id)");
-  public static final String MESSAGE = "message";
+  public static final String OVERVIEW_QUERY ="SELECT month,year,COALESCE(counts, 0) as counts\n" +
+          "FROM  (\n" +
+          "   SELECT day::date ,to_char(date_trunc('month', day),'month') as month,extract('year' from day) as year\n" +
+          "   FROM   generate_series(timestamp '$0'\n" +
+          "                        , timestamp '$1'\n" +
+          "                        , interval  '1 month') day\n" +
+          "   ) d\n" +
+          "LEFT  JOIN (\n" +
+          "   SELECT date_trunc('month', time)::date AS day\n" +
+          "        , count(api) as counts \n" +
+          "   FROM   auditing_rs\n" +
+          "   WHERE  time between '$2'\n" +
+          "   AND '$3'\n" ;
 
-  public static final String MONTHLY_OVERVIEW_QUERY = "select to_char(date_trunc('month', time),'month') as month\n" +
-          ",extract('year' from time) as year,\n" +
-          "count(api) as count from auditing_rs\n" +
-          "where time between "+ "'$0'" + " and " + "'$1'";
-  public static final String MONTHLY_OVERVIEW_GROUPBY = "\ngroup by month,year\n" +
-          "order by month";
-
+  public static final String GROUPBY = "\n" +
+          "   GROUP  BY 1\n" +
+          "   ) t USING (day)\n" +
+          "ORDER  BY day";
   public static final String SUMMARY_QUERY_FOR_METERING = "select resourceid,count(*) from auditing_rs group by resourceid";
   }

--- a/src/main/java/iudx/resource/server/metering/util/QueryBuilder.java
+++ b/src/main/java/iudx/resource/server/metering/util/QueryBuilder.java
@@ -134,52 +134,67 @@ public class QueryBuilder {
         LOGGER.debug("Year back =" + timeYearBack);
 
         if (startTime != null || endTime != null) {
+            ZonedDateTime timeSeries = ZonedDateTime.parse(startTime);
+            String timeSeriesToFirstDay = String.valueOf(timeSeries.withDayOfMonth(1));
+            LOGGER.debug("Time series = "+ timeSeriesToFirstDay);
             if (role.equalsIgnoreCase("admin")) {
                 monthQuery =
-                        new StringBuilder(MONTHLY_OVERVIEW_QUERY.concat(MONTHLY_OVERVIEW_GROUPBY)
-                                .replace("$0", startTime)
-                                .replace("$1", endTime));
+                        new StringBuilder(OVERVIEW_QUERY.concat(GROUPBY)
+                                .replace("$0", timeSeriesToFirstDay)
+                                .replace("$1", endTime)
+                                .replace("$2", startTime)
+                                .replace("$3", endTime));
             } else if (role.equalsIgnoreCase("consumer")) {
                 String userId = request.getString(USER_ID);
                 monthQuery =
-                        new StringBuilder(MONTHLY_OVERVIEW_QUERY.concat(" and userid = '$2' ").concat(MONTHLY_OVERVIEW_GROUPBY)
-                                .replace("$0", startTime)
+                        new StringBuilder(OVERVIEW_QUERY.concat(" and userid = '$4' ").concat(GROUPBY)
+                                .replace("$0", timeSeriesToFirstDay)
                                 .replace("$1", endTime)
-                                .replace("$2", userId));
+                                .replace("$2", startTime)
+                                .replace("$3", endTime)
+                                .replace("$4", userId));
             } else if (role.equalsIgnoreCase("provider") || role.equalsIgnoreCase("delegate")) {
                 String resourceId = request.getString(IID);
                 String providerID =
                         resourceId.substring(0, resourceId.indexOf('/', resourceId.indexOf('/') + 1));
                 LOGGER.debug("Provider =" + providerID);
                 monthQuery =
-                        new StringBuilder(MONTHLY_OVERVIEW_QUERY.concat(" and providerid = '$2' ").concat(MONTHLY_OVERVIEW_GROUPBY)
-                                .replace("$0", startTime)
+                        new StringBuilder(OVERVIEW_QUERY.concat(" and providerid = '$4' ").concat(GROUPBY)
+                                .replace("$0", timeSeriesToFirstDay)
                                 .replace("$1", endTime)
-                                .replace("$2", providerID));
+                                .replace("$2", startTime)
+                                .replace("$3", endTime)
+                                .replace("$4", providerID));
             }
         } else {
             if (role.equalsIgnoreCase("admin")) {
                 monthQuery =
-                        new StringBuilder(MONTHLY_OVERVIEW_QUERY.concat(MONTHLY_OVERVIEW_GROUPBY)
+                        new StringBuilder(OVERVIEW_QUERY.concat(GROUPBY)
                                 .replace("$0", timeYearBack)
-                                .replace("$1", utcTime.toString()));
+                                .replace("$1", utcTime.toString())
+                                .replace("$2", timeYearBack)
+                                .replace("$3", utcTime.toString()));
             } else if (role.equalsIgnoreCase("consumer")) {
                 String userId = request.getString(USER_ID);
                 monthQuery =
-                        new StringBuilder(MONTHLY_OVERVIEW_QUERY.concat(" and userid = '$2' ").concat(MONTHLY_OVERVIEW_GROUPBY)
+                        new StringBuilder(OVERVIEW_QUERY.concat(" and userid = '$4' ").concat(GROUPBY)
                                 .replace("$0", timeYearBack)
                                 .replace("$1", utcTime.toString())
-                                .replace("$2", userId));
+                                .replace("$2", timeYearBack)
+                                .replace("$3", utcTime.toString())
+                                .replace("$4", userId));
             } else if (role.equalsIgnoreCase("provider") || role.equalsIgnoreCase("delegate")) {
                 String resourceId = request.getString(IID);
                 String providerID =
                         resourceId.substring(0, resourceId.indexOf('/', resourceId.indexOf('/') + 1));
                 LOGGER.debug("Provider =" + providerID);
                 monthQuery =
-                        new StringBuilder(MONTHLY_OVERVIEW_QUERY.concat(" and providerid = '$2' ").concat(MONTHLY_OVERVIEW_GROUPBY)
+                        new StringBuilder(OVERVIEW_QUERY.concat(" and providerid = '$4' ").concat(GROUPBY)
                                 .replace("$0", timeYearBack)
                                 .replace("$1", utcTime.toString())
-                                .replace("$2", providerID));
+                                .replace("$2", timeYearBack)
+                                .replace("$3", utcTime.toString())
+                                .replace("$4", providerID));
             }
         }
 


### PR DESCRIPTION
Changes in query to also return months with 0 count in response.

```json
{
  "type":"success",
  "title":"success",
  "result":[
    { 
      "month":"december",
      "year":2022,
     "count":0
    },
   {
     "month":"January",
     "year":2023,
     "count":23363
   }
  ]
}


```