### PR TITLE
postman token request change for pune resource [open->closed] token

### DIFF
--- a/src/test/resources/IUDX-Resource-Server-Consumer-APIs-V4.0.postman_collection.json
+++ b/src/test/resources/IUDX-Resource-Server-Consumer-APIs-V4.0.postman_collection.json
@@ -39,7 +39,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"itemId\": \"rs.iudx.io\",\n  \"itemType\": \"resource_server\",\n  \"role\": \"consumer\"\n}",
+							"raw": "{\n  \"itemId\": \"iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/pune-env-flood/FWR055\",\n  \"itemType\": \"resource\",\n  \"role\": \"consumer\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3764,7 +3764,7 @@
 						"header": [
 							{
 								"key": "token",
-								"value": "{{secureResourceToken}}",
+								"value": "{{openResourceToken}}",
 								"type": "text"
 							}
 						],
@@ -3832,7 +3832,7 @@
 						"header": [
 							{
 								"key": "token",
-								"value": "{{secureResourceToken}}",
+								"value": "{{openResourceToken}}",
 								"type": "text"
 							}
 						],
@@ -19019,7 +19019,7 @@
 						"header": [
 							{
 								"key": "token",
-								"value": "{{delegateToken}}",
+								"value": "{{openResourceToken}}",
 								"type": "text"
 							}
 						],
@@ -19088,7 +19088,7 @@
 						"header": [
 							{
 								"key": "token",
-								"value": "{{delegateToken}}",
+								"value": "{{openResourceToken}}",
 								"type": "text"
 							}
 						],

--- a/src/test/resources/IUDX-Resource-Server-Consumer-APIs-V4.0.postman_collection.json
+++ b/src/test/resources/IUDX-Resource-Server-Consumer-APIs-V4.0.postman_collection.json
@@ -13058,7 +13058,7 @@
 						"header": [
 							{
 								"key": "token",
-								"value": "{{secureResourceToken}}",
+								"value": "{{openResourceToken}}",
 								"type": "text"
 							}
 						],
@@ -13361,7 +13361,7 @@
 						"header": [
 							{
 								"key": "token",
-								"value": "{{secureResourceToken}}",
+								"value": "{{openResourceToken}}",
 								"type": "text"
 							}
 						],
@@ -21890,7 +21890,7 @@
 						"header": [
 							{
 								"key": "token",
-								"value": "{{secureResourceToken}}",
+								"value": "{{openResourceToken}}",
 								"type": "text"
 							}
 						],
@@ -21962,7 +21962,7 @@
 						"header": [
 							{
 								"key": "token",
-								"value": "{{secureResourceToken}}",
+								"value": "{{openResourceToken}}",
 								"type": "text"
 							},
 							{
@@ -22036,7 +22036,7 @@
 						"header": [
 							{
 								"key": "token",
-								"value": "{{secureResourceToken}}",
+								"value": "{{openResourceToken}}",
 								"type": "text"
 							}
 						],
@@ -22247,7 +22247,7 @@
 						"header": [
 							{
 								"key": "token",
-								"value": "{{secureResourceToken}}",
+								"value": "{{openResourceToken}}",
 								"type": "text"
 							}
 						],


### PR DESCRIPTION
Since `pune-env-aqm` resource access policy changed to `Closed`, same changes are needed in postman collection else postman request will fail with `401:nvalidAuthorizationToken` status