### PR TITLE
Jenkins CI: Update image tag to 5.0.0-alpha [Master pipeline]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,7 +111,7 @@ pipeline {
           node('built-in') {
             script{
               publishHTML([allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true, reportDir: '/var/lib/jenkins/iudx/rs/Newman/report/', reportFiles: 'report.html', reportTitles: '', reportName: 'Integration Test Report'])
-              archiveZap failHighAlerts: 1, failMediumAlerts: 1, failLowAlerts: 4
+              archiveZap failHighAlerts: 1, failMediumAlerts: 1, failLowAlerts: 1
             }
           }
         }
@@ -146,8 +146,8 @@ pipeline {
           steps {
             script {
               docker.withRegistry( registryUri, registryCredential ) {
-                devImage.push("4.5.0-alpha-${env.GIT_HASH}")
-                deplImage.push("4.5.0-alpha-${env.GIT_HASH}")
+                devImage.push("5.0.0-alpha-${env.GIT_HASH}")
+                deplImage.push("5.0.0-alpha-${env.GIT_HASH}")
               }
             }
           }
@@ -155,7 +155,7 @@ pipeline {
         stage('Docker Swarm deployment') {
           steps {
             script {
-              sh "ssh azureuser@docker-swarm 'docker service update rs_rs --image ghcr.io/datakaveri/rs-depl:4.5.0-alpha-${env.GIT_HASH}'"
+              sh "ssh azureuser@docker-swarm 'docker service update rs_rs --image ghcr.io/datakaveri/rs-depl:5.0.0-alpha-${env.GIT_HASH}'"
               sh 'sleep 10'
             }
           }


### PR DESCRIPTION
- update image tag to `5.0.0-alpha` 
- reduced test failure thresholds according to last successful build