### PR TITLE
Bind auditing queue

### DIFF
--- a/src/main/java/iudx/resource/server/databroker/RabbitClient.java
+++ b/src/main/java/iudx/resource/server/databroker/RabbitClient.java
@@ -1319,7 +1319,11 @@ public class RabbitClient {
         .compose(
             dataIssueResult ->
                 bindQueue(QUEUE_ADAPTOR_LOGS, adaptorId, adaptorId + DOWNSTREAM_ISSUE, vhost))
-        .onSuccess(
+        .compose(
+                bindToAuditingQueueResult ->
+                bindQueue(QUEUE_AUDITING,adaptorId,topics,vhost)
+            )
+            .onSuccess(
             successHandler -> {
               JsonObject response = new JsonObject();
               response.mergeIn(

--- a/src/main/java/iudx/resource/server/databroker/util/Constants.java
+++ b/src/main/java/iudx/resource/server/databroker/util/Constants.java
@@ -86,6 +86,7 @@ public class Constants {
       "Queue already exists with different properties";
   public static final String QUEUE_DATA = "database";
   public static final String QUEUE_ADAPTOR_LOGS = "adaptorLogs";
+  public static final String QUEUE_AUDITING = "auditing-queue";
   public static final String REDIS_LATEST = "redis-latest";
   public static final String QUEUE_LIST_ERROR = "Listing of Queue failed";
   public static final String QUEUE_DELETE_ERROR = "Deletion of Queue failed";


### PR DESCRIPTION
- Bound every new exchange created during /ingestion API with the `auditing-queue`