### PR TITLE
Github Actions: Automatic image tag updates

### DIFF
--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -48,7 +48,7 @@ jobs:
         then
          git checkout -b rs-5.5.0-automatic-updates/$newtag5_5_0
 
-         # Uses sed to find and replace $oldtag4_5_0 with $newtag4_5_0 in Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml file
+         # Uses sed to find and replace $oldtag5_5_0 with $newtag5_5_0 in Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml file
          sed -i s/$oldtag5_5_0/$newtag5_5_0/g Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml
          
          # Exports the current version of the application from K8s-deployment/Charts/resource-server/Chart.yaml file

--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -1,4 +1,4 @@
-# This github workflow will automatically update docker image tags of rs-depl in the datakaveri/iudx-deployment repository files, whenever docker image is pushed to ghcr.io/datakaveri/rs-depl .Based on tag it will update the master/latest branch (if its 5.0.0-alpha-) or 4.5.0 stable branch (if its 4.5.0-)
+# This github workflow will automatically update docker image tags of rs-depl in the datakaveri/iudx-deployment repository files, whenever docker image is pushed to ghcr.io/datakaveri/rs-depl .Based on tag it will update  5.5.0 stable branch (if its 5.5.0-)
 
 name: Update RS docker image tags
 
@@ -29,27 +29,23 @@ jobs:
         GH_TOKEN: ${{ secrets.JENKINS_UPDATE}}
       run: | 
 
-        # Get the latest version of 4.5.0 and 5.0.0-alpha tags from the container registry using GitHub API
-        export newtag5_0_0=`(head -n1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/rs-depl/versions | jq ' .[].metadata.container.tags[0]'  | grep 5.0.0 | sed -e 's/^"//' -e 's/"$//'))`
-        export newtag4_5_0=`(head -n1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/rs-depl/versions | jq ' .[].metadata.container.tags[0]'  | grep 4.5.0 | grep -v alpha | sed -e 's/^"//' -e 's/"$//'))`
-
+        # Get the latest version of 5.5.0 tags from the container registry using GitHub API
+        export newtag5_5_0=$(head -n1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/rs-depl/versions | jq ' .[].metadata.container.tags[0]'  | grep 5.5.0 | sed -e 's/^"//' -e 's/"$//'))
         # Get the old tags from the YAML files
-        export oldtag5_0_0=`yq -r .services.rs.image Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml | cut -d : -f 2`
-        git checkout 4.5.0
-        export oldtag4_5_0=$(yq -r .services.rs.image Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml | cut -d : -f 2)      
+        export oldtag5_5_0=$(yq -r .services.rs.image Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml | cut -d : -f 2)
         
-         # Set Git user
+        # Set Git user
         git config --global user.name 'jenkins-datakaveri'
         git config --global user.email "96175780+jenkins-datakaveri@users.noreply.github.com"
 
 
         # Update the YAML files and create a new branch for each tag update
-        if [ "$newtag4_5_0" != "$oldtag4_5_0" ]
+        if [ "$newtag5_5_0" != "$oldtag5_5_0" ]
         then
-         git checkout -b rs-4.5.0-automatic-updates/$newtag4_5_0
+         git checkout -b rs-5.5.0-automatic-updates/$newtag5_5_0
 
          # Uses sed to find and replace $oldtag4_5_0 with $newtag4_5_0 in Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml file
-         sed -i s/$oldtag4_5_0/$newtag4_5_0/g Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml
+         sed -i s/$oldtag5_5_0/$newtag5_5_0/g Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml
          
          # Exports the current version of the application from K8s-deployment/Charts/resource-server/Chart.yaml file
 
@@ -62,41 +58,12 @@ jobs:
          sed -i s/$oldappversion/$newappversion/g K8s-deployment/Charts/resource-server/Chart.yaml
          sed -i s/$oldtag4_5_0/$newtag4_5_0/g K8s-deployment/Charts/resource-server/values.yaml
          git add Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml K8s-deployment/Charts/resource-server/values.yaml K8s-deployment/Charts/resource-server/Chart.yaml
-         git commit --allow-empty -m "updated rs docker image tag to $newtag4_5_0"
-         git push --set-upstream origin rs-4.5.0-automatic-updates/$newtag4_5_0
+         git commit --allow-empty -m "updated rs docker image tag to $newtag5_5_0"
+         git push --set-upstream origin rs-5.5.0-automatic-updates/$newtag5_5_0
 
          
-         # Creates a new pull request on the datakaveri/iudx-deployment repository with the base branch 4.5.0
+         # Creates a new pull request on the datakaveri/iudx-deployment repository with the base branch 5.5.0
 
-         gh pr create -R datakaveri/iudx-deployment --base 4.5.0 --fill 
-        fi
-        
-        if [ "$newtag5_0_0" != "$oldtag5_0_0" ]
-        then
-         git checkout master
-         git checkout -b rs-automatic-updates/$newtag5_0_0
-
-
-         # Uses sed to find and replace $oldtag5_0_0 with $newtag5_0_0 in Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml file
-         sed -i s/$oldtag5_0_0/$newtag5_0_0/g Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml
-         
-         # Exports the current version of the application from K8s-deployment/Charts/resource-server/Chart.yaml file
-
-         export oldappversion=`yq -r .version K8s-deployment/Charts/resource-server/Chart.yaml`
-         
-         # Uses awk to increment the version number in K8s-deployment/Charts/resource-server/Chart.yaml file
-         export newappversion=`yq -r .version K8s-deployment/Charts/resource-server/Chart.yaml | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{if(length($NF+1)>length($NF))$(NF-1)++; $NF=sprintf("%0*d", length($NF), ($NF+1)%(10^length($NF))); print}' `
-         
-         # Uses sed to find and replace $oldappversion with $newappversion in K8s-deployment/Charts/resource-server/Chart.yaml and K8s-deployment/Charts/resource-server/values.yaml files
-         sed -i s/$oldappversion/$newappversion/g K8s-deployment/Charts/resource-server/Chart.yaml
-         sed -i s/$oldtag5_0_0/$newtag5_0_0/g K8s-deployment/Charts/resource-server/values.yaml
-         git add Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml K8s-deployment/Charts/resource-server/values.yaml K8s-deployment/Charts/resource-server/Chart.yaml
-         git commit --allow-empty -m "updated rs docker image tag to $newtag5_0_0"
-         git push --set-upstream origin rs-automatic-updates/$newtag5_0_0
-
-         
-         # Creates a new pull request on the datakaveri/iudx-deployment repository with the base branch master
-
-         gh pr create -R datakaveri/iudx-deployment --base master --fill 
+         gh pr create -R datakaveri/iudx-deployment --base 5.5.0 --fill 
         fi
 

--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -1,4 +1,4 @@
-# This github workflow will automatically update docker image tags of rs-depl in the datakaveri/iudx-deployment repository files, whenever docker image is pushed to ghcr.io/datakaveri/rs-depl .Based on tag it will update  5.5.0 stable branch (if its 5.5.0-)
+# This github workflow will automatically update docker image tags of rs-depl in the datakaveri/iudx-deployment repository files, whenever docker image is pushed to ghcr.io/datakaveri/rs-depl .Based on tag it will update  master/latest branch (if its 5.5.1-alpha-) or 5.5.0 stable branch (if its 5.5.0-)
 
 name: Update RS docker image tags
 
@@ -31,7 +31,11 @@ jobs:
 
         # Get the latest version of 5.5.0 tags from the container registry using GitHub API
         export newtag5_5_0=$(head -n1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/rs-depl/versions | jq ' .[].metadata.container.tags[0]'  | grep 5.5.0 | grep -v alpha | sed -e 's/^"//' -e 's/"$//'))
+        export newtag5_5_1=`(head -n1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/rs-depl/versions | jq ' .[].metadata.container.tags[0]'  | grep 5.5.1 | sed -e 's/^"//' -e 's/"$//'))`
+
         # Get the old tags from the YAML files
+        export oldtag5_5_1=`yq -r .services.rs.image Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml | cut -d : -f 2`
+        git checkout 5.5.0
         export oldtag5_5_0=$(yq -r .services.rs.image Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml | cut -d : -f 2)
         
         # Set Git user
@@ -67,3 +71,31 @@ jobs:
          gh pr create -R datakaveri/iudx-deployment --base 5.5.0 --fill 
         fi
 
+        if [ "$newtag5_5_1" != "$oldtag5_5_1" ]
+        then
+         git checkout master
+         git checkout -b rs-automatic-updates/$newtag5.5.1
+
+
+         # Uses sed to find and replace $oldtag5.5.1 with $newtag5.5.1 in Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml file
+         sed -i s/$oldtag5.5.1/$newtag5.5.1/g Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml
+         
+         # Exports the current version of the application from K8s-deployment/Charts/resource-server/Chart.yaml file
+
+         export oldappversion=`yq -r .version K8s-deployment/Charts/resource-server/Chart.yaml`
+         
+         # Uses awk to increment the version number in K8s-deployment/Charts/resource-server/Chart.yaml file
+         export newappversion=`yq -r .version K8s-deployment/Charts/resource-server/Chart.yaml | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{if(length($NF+1)>length($NF))$(NF-1)++; $NF=sprintf("%0*d", length($NF), ($NF+1)%(10^length($NF))); print}' `
+         
+         # Uses sed to find and replace $oldappversion with $newappversion in K8s-deployment/Charts/resource-server/Chart.yaml and K8s-deployment/Charts/resource-server/values.yaml files
+         sed -i s/$oldappversion/$newappversion/g K8s-deployment/Charts/resource-server/Chart.yaml
+         sed -i s/$oldtag5.5.1/$newtag5.5.1/g K8s-deployment/Charts/resource-server/values.yaml
+         git add Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml K8s-deployment/Charts/resource-server/values.yaml K8s-deployment/Charts/resource-server/Chart.yaml
+         git commit --allow-empty -m "updated rs docker image tag to $newtag5.5.1"
+         git push --set-upstream origin rs-automatic-updates/$newtag5.5.1
+
+         
+         # Creates a new pull request on the datakaveri/iudx-deployment repository with the base branch master
+
+         gh pr create -R datakaveri/iudx-deployment --base master --fill 
+        fi

--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -60,7 +60,7 @@ jobs:
          
          # Uses sed to find and replace $oldappversion with $newappversion in K8s-deployment/Charts/resource-server/Chart.yaml and K8s-deployment/Charts/resource-server/values.yaml files
          sed -i s/$oldappversion/$newappversion/g K8s-deployment/Charts/resource-server/Chart.yaml
-         sed -i s/$oldtag4_5_0/$newtag4_5_0/g K8s-deployment/Charts/resource-server/values.yaml
+         sed -i s/$oldtag5_5_0/$newtag5_5_0/g K8s-deployment/Charts/resource-server/values.yaml
          git add Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml K8s-deployment/Charts/resource-server/values.yaml K8s-deployment/Charts/resource-server/Chart.yaml
          git commit --allow-empty -m "updated rs docker image tag to $newtag5_5_0"
          git push --set-upstream origin rs-5.5.0-automatic-updates/$newtag5_5_0
@@ -74,11 +74,11 @@ jobs:
         if [ "$newtag5_5_1" != "$oldtag5_5_1" ]
         then
          git checkout master
-         git checkout -b rs-automatic-updates/$newtag5.5.1
+         git checkout -b rs-automatic-updates/$newtag5_5_1
 
 
-         # Uses sed to find and replace $oldtag5.5.1 with $newtag5.5.1 in Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml file
-         sed -i s/$oldtag5.5.1/$newtag5.5.1/g Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml
+         # Uses sed to find and replace $oldtag5_5_1 with $newtag5_5_1 in Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml file
+         sed -i s/$oldtag5_5_1/$newtag5_5_1/g Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml
          
          # Exports the current version of the application from K8s-deployment/Charts/resource-server/Chart.yaml file
 
@@ -89,10 +89,10 @@ jobs:
          
          # Uses sed to find and replace $oldappversion with $newappversion in K8s-deployment/Charts/resource-server/Chart.yaml and K8s-deployment/Charts/resource-server/values.yaml files
          sed -i s/$oldappversion/$newappversion/g K8s-deployment/Charts/resource-server/Chart.yaml
-         sed -i s/$oldtag5.5.1/$newtag5.5.1/g K8s-deployment/Charts/resource-server/values.yaml
+         sed -i s/$oldtag5_5_1/$newtag5_5_1/g K8s-deployment/Charts/resource-server/values.yaml
          git add Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml K8s-deployment/Charts/resource-server/values.yaml K8s-deployment/Charts/resource-server/Chart.yaml
-         git commit --allow-empty -m "updated rs docker image tag to $newtag5.5.1"
-         git push --set-upstream origin rs-automatic-updates/$newtag5.5.1
+         git commit --allow-empty -m "updated rs docker image tag to $newtag5_5_1"
+         git push --set-upstream origin rs-automatic-updates/$newtag5_5_1
 
          
          # Creates a new pull request on the datakaveri/iudx-deployment repository with the base branch master

--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -30,7 +30,7 @@ jobs:
       run: | 
 
         # Get the latest version of 5.5.0 tags from the container registry using GitHub API
-        export newtag5_5_0=$(head -n1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/rs-depl/versions | jq ' .[].metadata.container.tags[0]'  | grep 5.5.0 | sed -e 's/^"//' -e 's/"$//'))
+        export newtag5_5_0=$(head -n1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/rs-depl/versions | jq ' .[].metadata.container.tags[0]'  | grep 5.5.0 | grep -v alpha | sed -e 's/^"//' -e 's/"$//'))
         # Get the old tags from the YAML files
         export oldtag5_5_0=$(yq -r .services.rs.image Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml | cut -d : -f 2)
         


### PR DESCRIPTION
This github workflow will automatically update docker image tags of rs-depl in the datakaveri/iudx-deployment repository files, whenever docker image is pushed to ghcr.io/datakaveri/rs-depl .Based on tag it will update   master/latest branch (if its 5.5.1-alpha-) or  5.5.0 stable branch (if its 5.5.0-)
